### PR TITLE
Meilleures traductions

### DIFF
--- a/js/lang/fr.js
+++ b/js/lang/fr.js
@@ -5,11 +5,11 @@ var msg = {};
 	
 	msg.UI = {};
 	msg.UI.m01 = 'BDC';
-	msg.UI.m02 = 'Dans cette section:'
-	msg.UI.m03 = 'S\'applique à:';
+	msg.UI.m02 = 'Dans cette section :'
+	msg.UI.m03 = 'S\'applique à :';
 	
 	msg.footer = {};
-	msg.footer.m01 = 'Pour signaler des fautes de frappe, des erreurs et des omissions, veuillez ouvrir un numéro dans la ';
+	msg.footer.m01 = 'Pour signaler des fautes de frappe, des erreurs et des omissions, veuillez ouvrir un ticket dans la ';
 	msg.footer.m02 = 'GitHub traquer';
 	msg.footer.m03 = 'Pour une liste des modifications apportées à cette page, reportez-vous à la ';
 	msg.footer.m04 = 'journal de commit'


### PR DESCRIPTION
1. The later is a more natural French expression.  You may compare GitHub's code search results for the [former](https://github.com/search?q=%22ouvrir+un+numéro%22&type=Code) and the [later](https://github.com/search?q=%22ouvrir+un+ticket%22&type=Code).
2. French colons are surrounded with spaces.
3. I wonder if you have the possibility to change line 16 to "Conditions générales d'utilisation", or simply "[CGU](https://fr.wikipedia.org/wiki/Conditions_g%C3%A9n%C3%A9rales_d%27utilisation)".  Every native French speaker will understand what it means.
https://github.com/daisy/kb/blob/e56359ae8e8ce94f93456ec658e93d99ee91790d/js/lang/fr.js#L16