### PR TITLE
update schema.org metadata examples to show multiple values

### DIFF
--- a/publishing/docs/metadata/schema.org/accessMode.html
+++ b/publishing/docs/metadata/schema.org/accessMode.html
@@ -29,35 +29,39 @@
 					<figcaption>
 						<div class="label">Example 1 &#8212; EPUB 3</div>
 					</figcaption>
-					<pre id="ex-epub3-src" class="prettyprint linenums"><code>&lt;meta property="schema:accessMode">textual&lt;/meta></code></pre>
+					<pre id="ex-epub3-src" class="prettyprint linenums"><code>&lt;meta property="schema:accessMode">textual&lt;/meta>
+&lt;meta property="schema:accessMode">visual&lt;/meta></code></pre>
 				</figure>
 
 				<figure id="ex-epub2">
 					<figcaption>
 						<div class="label">Example 2 &#8212; EPUB 2</div>
 					</figcaption>
-					<pre id="ex-epub2-src" class="prettyprint linenums"><code>&lt;meta name="schema:accessMode" content="textual"/></code></pre>
+					<pre id="ex-epub2-src" class="prettyprint linenums"><code>&lt;meta name="schema:accessMode" content="textual"/>
+&lt;meta name="schema:accessMode" content="visual"/></code></pre>
 				</figure>
 				
 				<figure id="ex-audiobooks">
 					<figcaption>
 						<div class="label">Example 3 &#8212; Audiobooks</div>
 					</figcaption>
-					<pre id="ex-audiobooks-src" class="prettyprint linenums"><code>"accessMode": ["textual"]</code></pre>
+					<pre id="ex-audiobooks-src" class="prettyprint linenums"><code>"accessMode": ["textual", "visual"]</code></pre>
 				</figure>
 				
 				<figure id="ex-rdfa">
 					<figcaption>
 						<div class="label">Example 4 &#8212; HTML with RDFa</div>
 					</figcaption>
-					<pre id="ex-rdfa-src" class="prettyprint linenums"><code>&lt;meta property="accessMode" content="textual"/></code></pre>
+					<pre id="ex-rdfa-src" class="prettyprint linenums"><code>&lt;meta property="accessMode" content="textual"/>
+&lt;meta property="accessMode" content="visual"/></code></pre>
 				</figure>
 
 				<figure id="ex-micro">
 					<figcaption>
 						<div class="label">Example 5 &#8212; HTML with microdata</div>
 					</figcaption>
-					<pre id="ex-micro-src" class="prettyprint linenums"><code>&lt;meta itemprop="accessMode" content="textual"/></code></pre>
+					<pre id="ex-micro-src" class="prettyprint linenums"><code>&lt;meta itemprop="accessMode" content="textual"/>
+&lt;meta itemprop="accessMode" content="visual"/></code></pre>
 				</figure>
 			</section>
 
@@ -71,7 +75,14 @@
 				<p>Adaptations are not identified using this property, as they are not the primary way that the content
 					is consumed. If adaptations, such as extended descriptions, are provided for the primary content,
 					they are used in determining the <a href="#accessModeSufficient">sufficient access modes</a>.</p>
-
+				
+				<div class="note" role="note" aria-labelledby="format-note">
+					<p class="label" id="format-note">Note</p>
+					<p>Unless the metadata format used supports lists (e.g., JSON), use a separate property declaration
+						for each access mode. Do not merge the values into a single property using spaces, commas, or
+						other delimiters.</p>
+				</div>
+				
 				<p>The following values are recommended for this property:</p>
 
 				<dl>

--- a/publishing/docs/metadata/schema.org/accessModeSufficient.html
+++ b/publishing/docs/metadata/schema.org/accessModeSufficient.html
@@ -89,6 +89,12 @@
 					consumed. If the images are also adequately described (alt text and extended descriptions, as
 					appropriate) a single textual mode would also be sufficient, indicating someone who is blind can
 					consume the content.</p>
+				
+				<div class="note" role="note" aria-labelledby="format-note">
+					<p class="label" id="format-note">Note</p>
+					<p>Unless the metadata format used supports lists of lists (e.g., JSON), use a separate property
+						declaration for each list of sufficient access modes. Separate the values with commas.</p>
+				</div>
 			</section>
 
 			<section id="refs">

--- a/publishing/docs/metadata/schema.org/accessibilityFeature.html
+++ b/publishing/docs/metadata/schema.org/accessibilityFeature.html
@@ -28,21 +28,23 @@
 					<figcaption>
 						<div class="label">Example 1 &#8212; EPUB 3</div>
 					</figcaption>
-					<pre id="ex-epub3-src" class="prettyprint linenums"><code>&lt;meta property="schema:accessibilityFeature">captions&lt;/meta></code></pre>
+					<pre id="ex-epub3-src" class="prettyprint linenums"><code>&lt;meta property="schema:accessibilityFeature">captions&lt;/meta>
+&lt;meta property="schema:accessibilityFeature">alternativeText&lt;/meta></code></pre>
 				</figure>
 
 				<figure id="ex-epub2">
 					<figcaption>
 						<div class="label">Example 2 &#8212; EPUB 2</div>
 					</figcaption>
-					<pre id="ex-epub2-src" class="prettyprint linenums"><code>&lt;meta name="schema:accessibilityFeature" content="captions"/></code></pre>
+					<pre id="ex-epub2-src" class="prettyprint linenums"><code>&lt;meta name="schema:accessibilityFeature" content="captions"/>
+&lt;meta name="schema:accessibilityFeature" content="alternativeText"/></code></pre>
 				</figure>
 				
 				<figure id="ex-audiobooks">
 					<figcaption>
 						<div class="label">Example 3 &#8212; Audiobooks</div>
 					</figcaption>
-					<pre id="ex-audiobooks-src" class="prettyprint linenums"><code>"accessibilityFeature": ["captions"]</code></pre>
+					<pre id="ex-audiobooks-src" class="prettyprint linenums"><code>"accessibilityFeature": ["captions", "alternativeText"]</code></pre>
 				</figure>
 				
 				<figure id="ex-rdfa">
@@ -67,7 +69,14 @@
 
 				<p>The following values are used to identify features of the content that are helpful for
 					accessibility:</p>
-
+				
+				<div class="note" role="note" aria-labelledby="format-note">
+					<p class="label" id="format-note">Note</p>
+					<p>Unless the metadata format used supports lists (e.g., JSON), use a separate property declaration
+						for each feature. Do not merge the values into a single property using spaces, commas, or other
+						delimiters.</p>
+				</div>
+				
 				<dl>
 					<dt id="alternativeText">alternativeText</dt>
 					<dd>

--- a/publishing/docs/metadata/schema.org/accessibilityHazard.html
+++ b/publishing/docs/metadata/schema.org/accessibilityHazard.html
@@ -30,21 +30,23 @@
 					<figcaption>
 						<div class="label">Example 1 &#8212; EPUB 3</div>
 					</figcaption>
-					<pre id="a11y-13-src" class="prettyprint linenums"><code>&lt;meta property="schema:accessibilityHazard">flashing&lt;/meta></code></pre>
+					<pre id="a11y-13-src" class="prettyprint linenums"><code>&lt;meta property="schema:accessibilityHazard">flashing&lt;/meta>
+&lt;meta property="schema:accessibilityHazard">motionSimulation&lt;/meta></code></pre>
 				</figure>
 
 				<figure id="ex-epub2">
 					<figcaption>
 						<div class="label">Example 2 &#8212; EPUB 2</div>
 					</figcaption>
-					<pre id="ex-epub2-src" class="prettyprint linenums"><code>&lt;meta name="schema:accessibilityHazard" content="flashing"/></code></pre>
+					<pre id="ex-epub2-src" class="prettyprint linenums"><code>&lt;meta name="schema:accessibilityHazard" content="flashing"/>
+&lt;meta name="schema:accessibilityHazard" content="motionSimulation"/></code></pre>
 				</figure>
 				
 				<figure id="ex-audiobooks">
 					<figcaption>
 						<div class="label">Example 3 &#8212; Audiobooks</div>
 					</figcaption>
-					<pre id="ex-audiobooks-src" class="prettyprint linenums"><code>"accessibilityHazard": ["flashing"]</code></pre>
+					<pre id="ex-audiobooks-src" class="prettyprint linenums"><code>"accessibilityHazard": ["flashing", "motionSimulation"]</code></pre>
 				</figure>
 				
 				<figure id="ex-rdfa">
@@ -73,7 +75,14 @@ individuals.&lt;/p></code></pre>
 
 				<p>The following values are used to identify potential hazards (or the lack thereof) so that users with
 					such sensitivities know what to expect in advance:</p>
-
+				
+				<div class="note" role="note" aria-labelledby="format-note">
+					<p class="label" id="format-note">Note</p>
+					<p>Unless the metadata format used supports lists (e.g., JSON), use a separate property declaration
+						for each feature. Do not merge the values into a single property using spaces, commas, or other
+						delimiters.</p>
+				</div>
+				
 				<dl>
 					<dt id="flashing">flashing</dt>
 					<dd>


### PR DESCRIPTION
Fixes #30:

- expands examples for accessMode, accessibilityFeature, and accessibilityHazard to show more than one value for the most pertinent formats
- adds a note about how to deal with multiple values to the above three and accessModeSufficient