### PR TITLE
fix typo in notes example 4

### DIFF
--- a/publishing/docs/html/notes.html
+++ b/publishing/docs/html/notes.html
@@ -105,7 +105,7 @@
 					</figcaption>
 					<pre id="ex-04-src" class="prettyprint linenums"><code>&lt;aside role="doc-footnote">
    &lt;p>&lt;a href="#ref" role="doc-backlink" title="Go to note reference">1.&lt;/a> According to the usual nomenclature, the &#8230;&lt;/p>
-&lt;/li></code></pre>
+&lt;/aside></code></pre>
 				</figure>
 				
 				<figure id="ex-05">


### PR DESCRIPTION
Example 4 on the [Notes](http://kb.daisy.org/publishing/docs/html/notes.html) page appears to have an incorrect close tag. This PR fixes that. 