### PR TITLE
Correction for CSS initial-letter property

### DIFF
--- a/publishing/docs/html/dropcaps.html
+++ b/publishing/docs/html/dropcaps.html
@@ -124,11 +124,11 @@
 					<p>For example, to create a drop cap two lines high, only the following CSS is needed:</p>
 					
 					<pre id="ex-il-css" class="prettyprint linenums"><code>section[@role='doc-chapter'] p:first-child {
-	initial-letter: 2.0;
+	initial-letter: 2;
 }</code></pre>
 					
-					<p>(Note that an integer value like "2.0" creates a drop cap, while a whole number like "2" would
-						create a raised cap.)</p>
+					<p>(Note that to create a raised cap, you would use 
+					<code>initial-letter: 2 1</code>)</p>
 					
 					<p>The problem with this approach is that there is currently <a
 							href="https://caniuse.com/?search=initial-letter">limited support for the property</a> (only


### PR DESCRIPTION
The example in the [drop cap page](http://kb.daisy.org/publishing/docs/html/dropcaps.html) shows

```CSS
section[@role='doc-chapter'] p:first-child {
	initial-letter: 2.0;
}
```

And there's a note:

> (Note that an integer value like "2.0" creates a drop cap, while a whole number like "2" would create a raised cap.)

This is not correct. The initial-letter property takes [two values](https://drafts.csswg.org/css-inline-3/#sizing-drop-initials): the first is the size of the drop cap, and the second is how many lines the drop cap sinks. `initial-letter: 2` is interpreted as `initial-letter: 2 2` which creates a two-line drop cap. It doesn't matter if the value is `2` or `2.0`. To create a raised cap you would use `initial-letter: 2 1`. 