### PR TITLE
Fixing incorrect links to MDN on list page

### DIFF
--- a/publishing/docs/html/lists.html
+++ b/publishing/docs/html/lists.html
@@ -187,10 +187,10 @@
 						href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol">&lt;ol>: The Ordered List
 						element</a></li>
 					<li>MDN &#8212; <a
-						href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol">&lt;ul>: The Unordered List
+						href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul">&lt;ul>: The Unordered List
 						element</a></li>
 					<li>MDN &#8212; <a
-						href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol">&lt;dl>: The Definition List
+						href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl">&lt;dl>: The Definition List
 						element</a></li>
 					<li>HTML &#8212; <a
 						href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element">The


### PR DESCRIPTION
Hi, discovered some errors in the MDN links on the KB page on lists, this PR fixes them.