### PR TITLE
Split the page navigation page into separate topics

### DIFF
--- a/js/topics/en.js
+++ b/js/topics/en.js
@@ -120,30 +120,62 @@ var topic_list = [
 		'subtitle': 'The navigation topics describe how to author accessible navigation aids.',
 		'id': 'nav',
 		'path': 'navigation',
-		'topics': [
+		'categories': [
 			{
-				'id': 'nav-contentlist',
-				'href': 'content-list.html',
-				'title': 'Content Lists',
-				'subtitle': 'Describes how to add lists of tables, figures, etc.'
+				'id': 'nav-aids',
+				'title': 'Publication Navigation',
+				'path': 'nav',
+				'topics': [
+					{
+						'id': 'nav-contentlist',
+						'href': 'content-list.html',
+						'title': 'Content Lists',
+						'subtitle': 'Describes how to add lists of tables, figures, etc.'
+					},
+					{
+						'id': 'nav-landmarks',
+						'href': 'landmarks.html',
+						'title': 'Landmarks',
+						'subtitle': 'Describes the EPUB concept of publication landmarks.'
+					},
+					{
+						'id': 'nav-toc',
+						'href': 'toc.html',
+						'title': 'Table of Contents',
+						'subtitle': 'Describes best practices for including tables of contents.'
+					}
+				]
 			},
 			{
-				'id': 'nav-landmarks',
-				'href': 'landmarks.html',
-				'title': 'Landmarks',
-				'subtitle': 'Describes the EPUB concept of publication landmarks.'
-			},
-			{
-				'id': 'nav-pagelist',
-				'href': 'pagelist.html',
+				'id': 'nav-page',
 				'title': 'Page Navigation',
-				'subtitle': 'Describes the purpose and construction of a page list.'
-			},
-			{
-				'id': 'nav-toc',
-				'href': 'toc.html',
-				'title': 'Table of Contents',
-				'subtitle': 'Describes best practices for including tables of contents.'
+				'path': 'nav',
+				'topics': [
+					{
+						'id': 'nav-pagenav',
+						'href': 'pagenav.html',
+						'title': 'Overview',
+						'subtitle': 'Introduction to the components of page navigation.'
+					},
+					{
+						'id': 'nav-pagebreaks',
+						'href': 'pagebreaks.html',
+						'title': 'Page Break Markers',
+						'subtitle': 'Describes the how to add page break markers.'
+					},
+					{
+						'id': 'nav-pagelist',
+						'href': 'pagelist.html',
+						'title': 'Page List',
+						'subtitle': 'Describes the purpose and construction of a page list.'
+					},
+					{
+						'id': 'nav-pagesrc',
+						'href': 'pagesrc.html',
+						'title': 'Page Source',
+						'subtitle': 'How to identify the source of pagination.'
+					}
+				]
 			}
 		]
 	},

--- a/publishing/docs/navigation/pagebreaks.html
+++ b/publishing/docs/navigation/pagebreaks.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>Page Break Markers</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="description" content="Guidance for including page break markers in digital publications.">
+		<script>
+			var page_info = {
+				'category': 'Navigation',
+				'appliesTo': ['Audiobooks', 'EPUB3','EPUB2'],
+				'related': ['nav-pagenav','nav-pagelist','nav-pagesrc']
+			};
+		</script>
+		<script src="/js/init.js"></script>
+	</head>
+	
+	<body>
+		<main>
+			<section id="summary">
+				<h3>Summary</h3>
+				
+				<p>Adding page break markers enables users of digital publications to discover the equivalent static
+					page they are on.</p>
+			</section>
+			
+			<section id="tech">
+				<h3>Techniques</h3>
+				
+				<ul>
+					<li>Identify page break locations in the text. [[WCAG-1.3.1]]</li>
+				</ul>
+			</section>
+
+			<section id="ex">
+				<h3>Examples</h3>
+
+				<figure id="ex-01">
+					<figcaption>
+						<div class="label">Example 1 &#8212; Page break marker (inline)</div>
+						<p>An empty <code>span</code> element identifies a page break inside a block element. It
+							is identified as a page break using the <code>role</code> attribute with the value
+							<code>doc-pagebreak</code>. The <code>aria-label</code> attribute provides a
+							pronounceable value.</p>
+					</figcaption>
+					<pre id="ex-01-src" class="prettyprint linenums"><code>&lt;p>
+   &#8230;
+   &lt;span
+       role="doc-pagebreak"
+       id="pg24"
+       aria-label="24"/>
+   &#8230;
+&lt;/p></code></pre>
+				</figure>
+				
+				<figure id="ex-02">
+					<figcaption>
+						<div class="label">Example 2 &#8212; Page break marker (block)</div>
+						
+						<p>A <code>div</code> element identifies a page break where inline elements are not allowed.
+							This example shows an example of a page number that is intended to be visible in the
+							content.</p>
+						
+						<p>(Note that the <code>aria-label</code> is currently required even when the number is visible.
+							A future version of the DPUB-ARIA module is expected to fix this so that the page number
+							is automatically obtained from the content of the element when a label is not specified.)</p>
+					</figcaption>
+					<pre id="ex-02-src" class="prettyprint linenums"><code>&lt;div role="doc-pagebreak" aria-label="page 24" id="pg24">24&lt;/div></code></pre>
+				</figure>
+			</section>
+			
+			<section id="faq">
+				<h3>Frequently Asked Questions</h3>
+				
+				<dl>
+					<dt id="faq-pb-001">What if the order of my ebook doesn't exactly match the order of the print
+						equivalent?</dt>
+					<dd><p>It is sometimes the case when converting to digital that front and back matter
+						material gets shuffled around and/or omitted. These changes in content order are not
+						unexpected, and users will understand that their ebooks may not be formatted exactly
+						the same way as the print, and may not include all the print content.</p>
+						<p>Do not renumber the page break markers to be sequential when the digital order is
+							different from the static source. Their purpose is to help users locate the static
+							equivalent location.</p>
+						<p>If some content is ordered differently in the digital version, or not included, best
+							practice is to make note of this in the <a 
+								href="../metadata/schema-org.html#accessibilitySummary">accessibility summary</a>
+							for the publication.</p>
+					</dd>
+					
+					<dt id="faq-pb-002">Does the page number reflect the page that is ending or the page that is
+						starting?</dt>
+					<dd><p>The page number always reflects the page that is starting.</p>
+					</dd>
+					
+					<dt id="faq-pb-003">Should the page break marker placement follow the print position?</dt>
+					<dd><p>No, page break markers are always placed at the start of the page's content,
+						regardless of whether the page number is printed at the top or bottom of the page in
+						the print edition. When a user jumps to a specific page, they want to jump to the start
+						of the content for that page, not the end.</p>
+					</dd>
+					
+					<dt id="faq-pb-004">Should I include the page numbers as content or empty elements?</dt>
+					<dd><p>There are pros and cons to each approach.</p>
+						<p>If you include the page numbers as text content within a <code>span</code> or 
+							<code>div</code>, the pages will be more easily accessible to both sighted users
+							and users using assistive technologies. This method has been employed in previous
+							DAISY standards. The potential downside, however, is that mainstream user agents
+							will not provide equivalent functionality to turn off unwanted content, forcing
+							users to hear and view the page numbers.</p>
+						<p>Page numbers as empty elements are the more traditional mainstream approach, with
+							anchor tags having served this function in the past. Using the 
+							<code>aria-label</code> attribute on an empty element, however, limits the users
+							who will have access to the page number while reading.</p>
+						<p>Although user agents don't support toggling the visibility of page numbers, it is
+							possible to provide the functionality using JavaScript. A script could be included
+							in each document to show/hide the numbers.</p>
+					</dd>
+					
+					<dt id="faq-pb-005">Should I use the <code>aria-label</code> or <code>title</code>
+						attribute for the page number?</dt>
+					<dd>
+						<p>The use of <code>aria-label</code> is recommended when the page number is not
+							included as text content, but both attributes can be used. <code>aria-label</code>
+							has higher precedence than <code>title</code> in the <a 
+								href="https://www.w3.org/TR/accname-1.1/">accessible name computation 
+								algorithm</a>.</p>
+					</dd>
+					
+					<dt id="faq-pb-006">Where do I put a page number when the page break occurs in the middle
+						of a list?</dt>
+					<dd><p>Lists often break across pages, with one item ending at the bottom of one and a new
+						item starting at the top of the next. In these cases, it is not possible to locate the
+						page number between the two list items, as it is not valid for a list to contain
+						anything but list items.</p>
+						<p>The obvious solutions are to either insert the page number as the very last element
+							in the item that ends the page:</p>
+						<pre><code>&lt;li>&#8230;. &lt;span role="doc-pagebreak" aria-label="24"/>&lt;/li>
+&lt;li>&#8230;&lt;/li>
+</code></pre>
+						<p>or to place it as the very first element in the list item that starts the page</p>
+						<pre><code>&lt;li>&#8230;&lt;/li>
+&lt;li>&lt;span role="doc-pagebreak" aria-label="24"/> &#8230; &lt;/li>
+</code></pre>
+						<p>One practice to avoid is creating a new list item just for the page break. As page
+							breaks are often not visible content, an empty list item will be confusing to all
+							users and may alter the meaning of the list.</p>
+					</dd>
+					
+					<dt id="faq-pb-007">Where do I put the page break if a word is hyphenated across a
+						page?</dt>
+					<dd><p>Place the page marker after the word. Do not retain the print hyphenation and insert
+						the number in the middle of the word.</p></dd>
+					
+					<dt id="faq-pb-009">Can I put the page break inside a heading?</dt>
+					<dd>
+						<p>No, do not put page breaks inside headings. If you do this, the page number will
+							become part of the accessible name for the section (i.e., it is calculated as part
+							of the text content of the heading).</p>
+						<p>Put the page break number before the heading tag. If you are using an empty element for the
+							page break (i.e., the value is in a <code>title</code> attribute as in <a 
+								href="#ex-01">example 1</a>), moving the page break before the heading will not add
+							add extra space to the layout.</p>
+					</dd>
+					
+					<dt id="faq-pb-008">Can I use <code>a</code> tags for page numbers?</dt>
+					<dd><p>The <code>a</code> element has two specific uses defined in HTML5: for links when
+						the <code>href</code> attribute is present, and for placeholder links when it is not
+						(e.g., a link that might be active in another context or after some interaction by the
+						user). As page breaks are not links, and are never intended to be activated as links,
+						it is not recommended to use them for page break markers.</p>
+					</dd>
+				</dl>
+			</section>
+			
+			<section id="desc">
+				<h3>Explanation</h3>
+				
+				<p>If a digital publication is produced from the same workflow as a print document, page break
+					locations should be retained. Retaining the page break locations can allow assistive
+					technologies and reading systems to announce the current page users are on and also allow users
+					to move forward or backward by page. (This functionality is not yet available for EPUBs.)</p>
+				
+				<p>Page break locations can be added to the markup using <code>span</code> and <code>div</code>
+					tags with a <code>role</code> attribute set to the value <code>doc-pagebreak</code>.</p>
+				
+				<pre id="expl-pb-01-src" class="prettyprint linenums"><code>&lt;div role="doc-pagebreak" id="pg2">2&lt;/div></code></pre>
+				
+				<p>To hide the page number from visual
+					viewing, the <code>aria-label</code> attribute can be used to identify the number.</p>
+				
+				<pre id="expl-pb-02-src" class="prettyprint linenums"><code>&lt;span role="doc-pagebreak" id="pg5" aria-label="5"/&lt;</code></pre>
+				
+				<p>The <code>id</code> attribute on the page break allows linking to the location from the page
+					list.</p>
+				
+				<p>Although page breaks have traditionally been retained for accessibility purposes (i.e., to allow
+					users who must use a digital version to coordinate with those using print), it is becoming
+					more common to find them as a general user aid. Digital-only publications (i.e., that do not
+					have a statically paginated source), often include page break markers to make it easier for
+					users to coordinate their position.</p>
+				
+				<div class="note" role="note" aria-labelledby="epub2-pb-note">
+					<p id="epub2-pb-note" class="label">Note</p>
+					
+					<p>In EPUB 2, it is not possible to include a semantic that identifies page break locations in
+						the content, as XHTML 1.1 does not support either the ARIA <code>role</code> or
+						<code>epub:type</code> attributes.</p>
+				</div>
+			</section>
+			
+			<section id="refs">
+				<h3>Related Links</h3>
+
+				<ul>
+					<li>HTML &#8212; <a href="https://html.spec.whatwg.org/multipage/sections.html#the-nav-element">The <code>nav</code>
+						element</a></li>
+					<li>DPUB-ARIA &#8212; <a href="https://www.w3.org/TR/dpub-aria/#doc-pagebreak">doc-pagebreak property</a></li>
+					<li>EPUB 3 &#8212; <a href="https://www.w3.org/TR/epub-ssv/#pagebreak">pagebreak property</a></li>
+				</ul>
+			</section>
+		</main>
+	</body>
+</html>

--- a/publishing/docs/navigation/pagelist.html
+++ b/publishing/docs/navigation/pagelist.html
@@ -2,13 +2,14 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
-		<title>Page Navigation</title>
+		<title>Page List</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="description" content="Guidance for including a page list in an EPUB publication.">
+		<meta name="description" content="Guidance for including a page list in a digital publication.">
 		<script>
 			var page_info = {
 				'category': 'Navigation',
-				'appliesTo': ['Audiobooks', 'EPUB3','EPUB2']
+				'appliesTo': ['Audiobooks', 'EPUB3','EPUB2'],
+				'related': ['nav-pagenav','nav-pagebreaks','nav-pagesrc']
 			};
 		</script>
 		<script src="/js/init.js"></script>
@@ -19,17 +20,15 @@
 			<section id="summary">
 				<h3>Summary</h3>
 				
-				<p>A page list and page break indicators allow users in mixed print-digital environments to coordinate their 
-					positions.</p>
+				<p>Include a page list so users of digital publications can coordinate their position with a statically
+					paginated equivalent.</p>
 			</section>
 			
 			<section id="tech">
 				<h3>Techniques</h3>
 				
 				<ul>
-					<li>Include a page list when a publication has statically-paginated equivalent. [[WCAG-2.4.5]]</li>
-					<li>Identify page break locations in the text. [[WCAG-1.3.1]]</li>
-					<li>Identify the source of the page breaks in the metadata. [[WCAG-1.3.1]]</li>
+					<li>Include a page list when a publication has statically paginated equivalent. [[WCAG-2.4.5]]</li>
 				</ul>
 			</section>
 
@@ -64,7 +63,8 @@
 						<div class="label">Example 2 &#8212; Page list (Web)</div>
 						<p>A page list for use on the Web generally is identified by the <code>role</code> attribute 
 							value <code>doc-pagelist</code>. The <code>aria-label</code> attribute is used to provide
-							a title for the navigation element, but an explicit heading can also be used.</p>
+							a title for the navigation element, but an explicit heading can also be used (refer to the
+							second <code>nav</code> element).</p>
 					</figcaption>
 					<pre id="ex-02-src" class="prettyprint linenums"><code>&lt;nav role="doc-pagelist" aria-label="Page list">
  &lt;ol>
@@ -115,139 +115,29 @@
     &lt;/pageList>
 &lt;/ncx></code></pre>
 				</figure>
-				
-				<figure id="ex-04">
-					<figcaption>
-						<div class="label">Example 4 &#8212; Page break marker (inline)</div>
-						<p>An empty <code>span</code> element identifies a page break inside a block element. It
-							is identified as a page break using the <code>role</code> attribute with the value
-							<code>doc-pagebreak</code>. The <code>aria-label</code> attribute provides an
-							announceable value.</p>
-					</figcaption>
-					<pre id="ex-04-src" class="prettyprint linenums"><code>&lt;p>
-   &#8230;
-   &lt;span
-       role="doc-pagebreak"
-       id="pg24"
-       aria-label="24"/>
-   &#8230;
-&lt;/p></code></pre>
-				</figure>
-				
-				<figure id="ex-05">
-					<figcaption>
-						<div class="label">Example 5 &#8212; Page break marker (block)</div>
-						
-						<p>A <code>div</code> element identifies a page break where inline elements are not allowed.
-							This example shows an example of a page number that is intended to be visible in the
-							content.</p>
-						
-						<p>(Note that the <code>aria-label</code> is currently required even when the number is visible.
-							A future version of the DPUB-ARIA module is expected to fix this so that the page number
-							is automatically obtained from the content of the element when a label is not specified.)</p>
-					</figcaption>
-					<pre id="ex-05-src" class="prettyprint linenums"><code>&lt;div role="doc-pagebreak" aria-label="page 24" id="pg24">24&lt;/div></code></pre>
-				</figure>
-				
-				<figure id="ex-06">
-					<figcaption>
-						<div class="label">Example 6 &#8212; Page break source identification (<code>source-of</code>)</div>
-						
-						<p>The additional <code>source-of</code> property is used to declare that the <code>dc:source</code>
-							element contains the ISBN of the print source for the pagination. The <code>refines</code> attribute
-							must be present and reference the ID of the <code>dc:source</code> element.</p>
-					</figcaption>
-					<pre id="ex-06-src" class="prettyprint linenums"><code>&lt;dc:source id="src">urn:isbn:9781234567891&lt;/dc:source>
-&lt;meta property="source-of" refines="#src">pagination&lt;/meta></code></pre>
-				</figure>
-				
-				<figure id="ex-07">
-					<figcaption>
-						<div class="label">Example 7 &#8212; Page break source identification (<code>pageBreakSource</code>)</div>
-						
-						<p>Unlike having to pair <code>dc:source</code> and <code>source-of</code> properties to identify the
-							pagination source, the <code>pageBreakSource</code> property only requires the identifier for
-							static page source (i.e., it can do in one property what previously required two).</p>
-						
-						<p><strong>Caution:</strong> this property is not yet part of EPUB 3 and causes an error when validating 
-							using epubcheck. See the <a href="#pbs">description below</a> for more information.</p>
-					</figcaption>
-					<pre id="ex-07-src" class="prettyprint linenums"><code>&lt;meta property="pageBreakSource">urn:isbn:9781234567891&lt;/meta></code></pre>
-				</figure>
 			</section>
 			
 			<section id="faq">
 				<h3>Frequently Asked Questions</h3>
 				
 				<dl>
-					<dt id="faq-001">What if the order of my ebook doesn't exactly match the order of the print
-						equivalent?</dt>
-					<dd><p>It is sometimes the case when converting to digital that front and back matter material gets
-						shuffled around and/or omitted. These changes in content order are not unexpected, and users
-						will understand that their ebooks may not be formatted exactly the same way as the print, and may
-						not include all the print content.</p>
-						<p>If some content is ordered differently in the digital version, or not included, best practice 
-							is to make note of this in the <a href="../metadata/schema-org.html#accessibilitySummary">accessibility 
-								summary</a> for the publication.</p>
-					</dd>
-					<dt id="faq-002">Does the page number reflect the page that is ending or the page that is
-						starting?</dt>
-					<dd><p>The page number always reflects the page that is starting.</p>
-					</dd>
-					<dt id="faq-003">Should the page break marker placement follow the print position?</dt>
-					<dd><p>No, page break markers are always placed at the start of the page's content, regardless of whether
-						the page number is printed at the top or bottom of the page in the print edition. When a user
-						jumps to a specific page, they want to jump to the start of the content for that page, not the
-						end.</p>
-					</dd>
-					<dt id="faq-004">Should I include the page numbers as content or empty elements?</dt>
-					<dd><p>There are pros and cons to each approach.</p>
-						<p>If you include the page numbers as text content within a <code>span</code> or <code>div</code>,
-							the pages will be more easily accessible to both sighted users and users using assistive
-							technologies. This method has been employed in previous DAISY standards. The potential downside,
-							however, is that mainstream user agents will not provide equivalent functionality to turn off
-							unwanted content, forcing users to hear and view the page numbers.</p>
-						<p>Page numbers as empty elements are the more traditional mainstream approach, with anchor tags
-							having served this function in the past. Using the <code>aria-label</code> attribute on an empty
-							element, however, limits the users who will have access to the page number while reading.</p>
-						<p>Although user agents don't support toggling the visibility of page numbers, it is possible
-							to provide the functionality using JavaScript. A script could be included in each document to
-							show/hide the numbers.</p>
-					</dd>
-					<dt id="faq-005">Should I use the <code>aria-label</code> or <code>title</code> attribute for the page number?</dt>
+					<dt id="faq-pl-001">How should I order the links the page list?</dt>
 					<dd>
-						<p>The use of <code>aria-label</code> is recommended when the page number is not included as text
-							content, but both attributes can be used. <code>aria-label</code> has higher precedence than
-							<code>title</code> in the <a href="https://www.w3.org/TR/accname-1.1/">accessible name computation
-								algorithm</a>.</p>
+						<p>There is currently no requirement on how to order the links in the page list. A
+							common technique is to order the links numerically, but sometimes the order of the
+							content in the digital publication does not match the order in the physical (e.g.,
+							sometimes the publisher might move front matter to the back). Some EPUB creators 
+							prefer to order the page list to match the digital content in these cases.</p>
 					</dd>
-					<dt id="faq-006">Where do I put a page number when the page break occurs in the middle of a
-						list?</dt>
-					<dd><p>Lists often break across pages, with one item ending at the bottom of one and a new item starting
-						at the top of the next. In these cases, it is not possible to locate the page number between the
-						two list items, as it is not valid for a list to contain anything but list items.</p>
-						<p>The obvious solutions are to either insert the page number as the very last element in the item
-							that ends the page:</p>
-						<pre><code>&lt;li>&#8230;. &lt;span role="doc-pagebreak" aria-label="24"/>&lt;/li>
-&lt;li>&#8230;&lt;/li>
-</code></pre>
-						<p>or to place it as the very first element in the list item that starts the page</p>
-						<pre><code>&lt;li>&#8230;&lt;/li>
-&lt;li>&lt;span role="doc-pagebreak" aria-label="24"/> &#8230; &lt;/li>
-</code></pre>
-						<p>One practice to avoid is creating a new list item just for the page break. As page breaks are
-							often not visible content, an empty list item will be confusing to all users and may alter the
-							meaning of the list.</p>
-					</dd>
-					<dt id="faq-007">Where do I put the page break if a word is hyphenated across a page?</dt>
-					<dd><p>Place the page marker after the word. Do not retain the print hyphenation and insert
-						the number in the middle of the word.</p></dd>
-					<dt id="faq-008">Can I use <code>a</code> tags for page numbers?</dt>
-					<dd><p>The <code>a</code> element has two specific uses defined in HTML5: for links when the
-						<code>href</code> attribute is present, and for placeholder links when it is not (e.g., a
-						link that might be active in another context or after some interaction by the user). As page
-						breaks are not links, and are never intended to be activated as links, it is not recommended to 
-						use them for page break markers.</p>
+					
+					<dt id="faq-pl-002">Does a publication with a page list have to have page break markers?</dt>
+					<dd>
+						<p>A page list may be included in a digital publication that does not have page break
+							markers, but this practice tends to be rare and is often not very helpful for 
+							users. An example would be a page list that only links to the first page of each
+							chapter. The page list could link to the chapter headings instead of having a page
+							break marker. But since the table of contents would already provide access to each
+							chapter, this approach has limited use.</p>
 					</dd>
 				</dl>
 			</section>
@@ -255,62 +145,33 @@
 			<section id="desc">
 				<h3>Explanation</h3>
 				
-				<p>If a reflowable publication is derived from a statically paginated source, such as a print edition, including
-					a page list allows users to coordinate positions. For example, a student using a digital edition in a class
-					where her peers are using print books would be able to jump to the same pages during instruction.</p>
+				<p>If a reflowable publication is derived from a statically paginated source, such as a print
+					edition, including a page list allows users to coordinate positions. For example, a student
+					using a digital edition in a class where her peers are using print books would be able to jump
+					to the same pages during instruction.</p>
 				
-				<p>The page list itself is a list of links to all the page breaks locations. User agents can use this list to
-					provide automatic page jump functionality, or a user can access it directly to manually select the page they
-					wish to go to.</p>
+				<p>The page list itself is a list of links to all the page break locations. User agents can use
+					this list to provide automatic page jump functionality, or a user can access it directly to
+					manually select the page they wish to go to.</p>
 				
-				<p>If a digital publication is produced from the same workflow as a print document, page break locations should also be
-					retained (although a page list can be created without explicit page break markers so long as there is some anchor for
-					the link to go to). Page break locations can be added to the markup using <code>span</code> and <code>div</code> tags with a
-					<code>role</code> attribute set to the value <code>doc-pagebreak</code>. To hide the page number from
-					visual viewing, the <code>aria-label</code> attribute can be used to identify the number.</p>
+				<p>In EPUB 3, the page list is expressed in a <a 
+					href="https://www.w3.org/TR/epub-33/#sec-nav-pagelist">page list nav element</a> in the
+					navigation document. This element is essentially a flat list of links to each page break
+					location.</p>
 				
-				<p>An <code>id</code> attribute has to be attached to each page break location to enable 
-					linking to the breaks.</p>
-				
-				<p>Identifying the source of the pagination in the publication metadata is also important to help users determine the 
-					usability of the pagination (e.g., will it match the print edition being used in a class).</p>
-				
-				<p>The current way to identify the pagination source in EPUB is through a combination of <code>dc:source</code> and
-					<code>source-of</code> metadata properties (see <a href="#ex-06">example 6</a>). This approach has two
-					serious flaws, however: one is that it only works for EPUB (refining metadata does not work in other
-					frameworks); the other is that it does not work for digital-only editions (i.e., where the page breaks
-					do not have a source).</p>
-				
-				<p id="pbs">A replacement method that uses only a single property called <code>pageBreakSource</code> is now
-					being incubated (see <a href="#ex-07">example 7</a>). The value of this property will either be the identifier
-					for the statically paginated source (e.g., its ISBN) or the value "none" if the page breaks were created
-					specifically for the digital edition.</p>
-				
-				<p>As this property is not yet formally part of EPUB 3, however, its use may result in errors when validating
-					using a publication using epubcheck. If a clean error report is required, the older approach must still
-					be used. A future release of epubcheck is expected to allow this property, at which time this page will
-					be updated to fully recommend its use.</p>
-				
-				<p>Refer to <a href="https://www.w3.org/publishing/a11y/page-source-id/">Page Source Identification</a> for more
-					information about the <code>pageBreakSource</code> property.</p>
-				
-				<section>
-					<h4>EPUB 2</h4>
+				<pre id="expl-pl-01-src" class="prettyprint linenums"><code>&lt;nav epub:type="page-list">
+ &lt;ol>
+   &lt;li>&lt;a href="chapter01.xhtml#page1">1&lt;/a>&lt;/li>
+   &lt;li>&lt;a href="chapter01.xhtml#page2">2&lt;/a>&lt;/li>
+   &#8230;
+ &lt;/ol>
+&lt;/nav></code></pre>
 					
-					<p>In EPUB 2, a page list is expressed using the
-						<a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1.2"><code>pageList</code> element</a>
-						in the NCX file. It is not possible to include a semantic that identifies page break locations in the content,
-						as XHTML 1.1 does not support either the ARIA <code>role</code> or <code>epub:type</code> attributes.</p>
-				</section>
-				
-				<section>
-					<h4>EPUB 3</h4>
-					
-					<p>In EPUB 3, the page list is included in the navigation document and identified with the <code>epub:type</code> value
-						<code>page-list</code>.</p>
-				</section>
+				<p>In EPUB 2, a page list is expressed using the
+					<a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1.2">
+						<code>pageList</code> element</a> in the NCX file. (See <a href="#ex-02">example 2</a>.)</p>
 			</section>
-
+			
 			<section id="refs">
 				<h3>Related Links</h3>
 
@@ -319,7 +180,6 @@
 						element</a></li>
 					<li>EPUB 3 &#8212; <a href="https://www.w3.org/TR/epub/#sec-nav-pagelist"
 							>The <code>page-list nav</code> Element</a></li>
-					<li>EPUB 3 &#8212; <a href="https://www.w3.org/TR/epub-ssv/#pagebreak">pagebreak property</a></li>
 					<li>EPUB 2 &#8212; <a href="http://www.daisy.org/z3986/2005/Z3986-2005.html#li_392a"><code>pageList</code>
 						element</a></li>
 				</ul>

--- a/publishing/docs/navigation/pagenav.html
+++ b/publishing/docs/navigation/pagenav.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>Page Navigation</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="description" content="Guidance for including page navigation a digital publication.">
+		<script>
+			var page_info = {
+				'category': 'Navigation',
+				'related': ['nav-pagebreaks','nav-pagelist','nav-pagesrc']
+			};
+		</script>
+		<script src="/js/init.js"></script>
+	</head>
+	
+	<body>
+		<main>
+			<section id="desc" aria-label="overview">
+				<p>Providing page navigation in digital publications has many benefits. It allows users in mixed
+					print-digital environments, such as schools, to easily coordinate locations (e.g., all students can
+					reach the same page, regardless of whether they have the print or digital edition, when instructed
+					by the teacher). It also has general benefits for digital-only publications, where users would
+					otherwise be forced to use the same reading systems, often with the same text settings, to
+					coordinate digital locations.</p>
+				
+				<p>There are three key aspects to page navigation:</p>
+				
+				<ul>
+					<li>Adding <a href="pagebreaks.html">page break markers</a> to the publication.</li>
+					<li>Including a <a href="pagelist.html">page list</a> to allow users to access the page breaks.</li>
+					<li>Identifying the <a href="pagesrc.html">source of the pagination</a> when it comes from a 
+						statically paginated source.</li>
+				</ul>
+				
+				<p>Page break markers are special markup destinations in a digital publication. They provide assistive
+					technologies information about the current page the user is on and also provide the link ends for a
+					page list. For more information, refer to the knowledge base's <a href="pagebreaks.html">Page 
+						Breaks</a> page.</p>
+				
+				<p>The page list provides essential information to reading systems to implement "go to page"
+					functionality. It is a list of links to all the page break destinations in the digital publication.
+					Users typically are not provided the entire list of pages to dig through, such as with the table of
+					contents. For more information, refer to the knowledge base's <a href="pagelist.html">Page 
+						List</a> page.</p>
+				
+				<p>Identifying the source of pagination is the final piece to providing page navigation. Users need to
+					know what statically paginated source the page breaks and page list align to when deciding whether
+					the pagination will be useful (e.g., does it match the physical textbook their classmates are
+					using). The pagination source is provided in the metadata for the digital publication. For more
+					information, refer to the knowledge base's <a href="pagesrc.html">Pagination Source</a> page.</p>
+				
+				<p>Not all of these aspects will be present in every digital publication with pagination. A publication
+					might only have a page list, for example, and omit the page break markers, or a digital-only
+					publication would not have a source for its pagination. In general, though, digital publications
+					that provide page navigation for accessibility will include them all.</p>
+			</section>
+		</main>
+	</body>
+</html>

--- a/publishing/docs/navigation/pagesrc.html
+++ b/publishing/docs/navigation/pagesrc.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>Page Source</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="description" content="Guidance for identifying the source of pagination in a digital publication.">
+		<script>
+			var page_info = {
+				'category': 'Navigation',
+				'appliesTo': ['Audiobooks', 'EPUB3','EPUB2'],
+				'related': ['nav-pagenav','nav-pagebreaks','nav-pagelist']
+			};
+		</script>
+		<script src="/js/init.js"></script>
+	</head>
+	
+	<body>
+		<main>
+			<section id="summary">
+				<h3>Summary</h3>
+				
+				<p>Identify the source of pagination so users can be sure the digital publication will be useful for
+					their needs.</p>
+			</section>
+			
+			<section id="tech">
+				<h3>Techniques</h3>
+				
+				<ul>
+					<li>Identify the source of the page breaks in the metadata. [[WCAG-1.3.1]]</li>
+				</ul>
+			</section>
+
+			<section id="ex">
+				<h3>Examples</h3>
+
+				<figure id="ex-01">
+					<figcaption>
+						<div class="label">Example 1 &#8212; Page break source identification (<code>pageBreakSource</code>)</div>
+						
+						<p>Unlike having to pair <code>dc:source</code> and <code>source-of</code> properties to identify the
+							pagination source, the <code>pageBreakSource</code> property only requires the identifier for
+							static page source (i.e., it can do in one property what previously required two).</p>
+					</figcaption>
+					<pre id="ex-01-src" class="prettyprint linenums"><code>&lt;meta property="pageBreakSource">urn:isbn:9781234567891&lt;/meta></code></pre>
+				</figure>
+				
+				<figure id="ex-02">
+					<figcaption>
+						<div class="label">Example 2 &#8212; Page break source identification (<code>source-of</code>)</div>
+						
+						<p>This example uses the old <code>source-of</code> property to identify the pagination source.
+							<strong>This method is no longer recommended.</strong> Refer to the <a href="#faq-001">FAQ
+								entry</a> below for more information.</p>
+					</figcaption>
+					<pre id="ex-02-src" class="prettyprint linenums"><code>&lt;dc:source id="pg-src">urn:isbn:9781234567891&lt;/dc:source>
+&lt;meta property="source-of" refines="#pg-src">pagination&lt;/meta></code></pre>
+				</figure>
+			</section>
+			
+			<section id="faq">
+				<h3>Frequently Asked Questions</h3>
+				
+				<dl>
+					<dt id="faq-001">Should I use the <code>source-of</code> or <code>pageBreakSource</code> property?</dt>
+					<dd>
+						<p>The older way to identify the pagination source in EPUB is through a combination of 
+							<code>dc:source</code> and <code>source-of</code> metadata properties. This approach has two
+							serious flaws, however: one is that it only works for EPUB (refining metadata does not work 
+							in other frameworks); the other is that it does not work for digital-only editions (i.e., 
+							where the page breaks do not have a source).</p>
+						
+						<p id="pbs">The replacement method that uses only a single property called 
+							<code>pageBreakSource</code> is now preferred (see <a href="#ex-07">example 7</a>).
+							Although it will take another revision of EPUB before this property is fully integrated
+							into the standard, there are no barriers to using it. Epubcheck correctly validates the
+							property.</p>
+						
+						<p>The value of the <code>pageBreakSource</code> property can be set to "none" if the page 
+							breaks were created specifically for the digital edition, overcoming the problem
+							of using <code>dc:source</code>.</p>
+						
+						<p>Refer to <a href="https://www.w3.org/publishing/a11y/page-source-id/">Page Source 
+							Identification</a> for more information about the <code>pageBreakSource</code> property.</p>
+					</dd>
+					
+					<dt id="faq-002">What if the pagination source does not have a unique identifier like an ISBN?</dt>
+					<dd>
+						<p>It is not required that the <code>pageBreakSource</code> property contain a unique identifier,
+							only that it uniquely identify the source. In the absence of a unique identifier, create a
+							unique name for the source document using the information you have about it.</p>
+						
+						<p>There are many types of documents with static pagination but without unique identifiers that
+							can be represented as EPUBs &#8212; PDF manuals, word processing documents, etc.</p>
+						
+						<p>For these types of documents, you can minimally use the title to identify the page break 
+							source. For greater specificity, add the author(s), creation date, etc. to the
+							identifier.</p>
+						
+						<pre><code>&lt;metadata &#8230;>
+&#8230;
+&lt;meta property="pageBreakSource">
+ACME Explosive Tennis Balls - 
+User Manual, 5th Edition, PDF
+&lt;/meta>
+&#8230;
+&lt;/metadata></code></pre>
+					</dd>
+				</dl>
+			</section>
+			
+			<section id="desc">
+				<h3>Explanation</h3>
+				
+				<p>Although the <a href="pagelist.html">page list</a> and <a href="pagebreaks.html">page break
+					markers</a> are the technologies that allow users to access static page break locations, without
+					knowing the source of the pagination, users cannot determine the usefulness of a digital
+					publication. A student in a classroom, for example, needs to know whether the pagination was
+					derived from the same version of a print book that the rest of their class is using.</p>
+				
+				<p>The source of the pagination is identified using the <code>pageBreakSource</code> property.</p>
+				
+				<pre id="expl-01-src" class="prettyprint linenums"><code>&lt;meta property="pageBreakSource">urn:isbn:9780123456789&lt;/meta></code></pre>
+				
+				<p>The value of the property is a unique identifier for the statically paginated source, such as
+					its ISBN.</p>
+			</section>
+				
+			<section id="refs">
+				<h3>Related Links</h3>
+
+				<ul>
+					<li>EPUB &#8212; <a href="https://www.w3.org/publishing/a11y/page-source-id/">Page Source
+						Identification</a></li>
+				</ul>
+			</section>
+		</main>
+	</body>
+</html>

--- a/publishing/docs/new/feed.xml
+++ b/publishing/docs/new/feed.xml
@@ -5,9 +5,32 @@
 		<description>Recent updates to the DAISY Accessible Publishing KB</description>
 		<link>https://kb.daisy.org/publishing/docs</link>
 		<copyright>2023 DAISY. All rights reserved</copyright>
-		<lastBuildDate>Mon, 16 Oct 2023 00:01:00 +0500</lastBuildDate>
-		<pubDate>Mon, 16 Oct 2023 11:00:00 +0500</pubDate>
+		<lastBuildDate>Thurs, 22 Feb 2024 00:01:00 +0500</lastBuildDate>
+		<pubDate>Thurs, 22 Feb 2024 11:00:00 +0500</pubDate>
 		<ttl>1440</ttl>
+		
+		<item>
+			<title>Expanded guidance on page navigation</title>
+			<link>https://kb.daisy.org/publishing/docs/navigation/pagenav.html</link>
+			<description>
+				<![CDATA[
+				<p>The page on page navigation is now split in four:</p>
+				<ul>
+					<li><a href="https://kb.daisy.org/publishing/docs/nav/pagenav.html">Overview</a></li>
+					<li><a href="https://kb.daisy.org/publishing/docs/nav/pagebreaks.html">Page Breaks</a></li>
+					<li><a href="https://kb.daisy.org/publishing/docs/nav/pagelist.html">Page List</a></li>
+					<li><a href="https://kb.daisy.org/publishing/docs/nav/pagesrc.html">Page Source</a></li>
+				</ul>
+				<p>These pages provide additional context on their respective topics, as well as update and expand
+					on the examples and frequently asked questions.</p>
+				
+				<p>Some of the new issues covered include not adding page breaks to headings, how to identify the
+					source of pagination when the source does not have a unique identifier, and that preference
+					should now be given to the <code>pageBreakSource</code> property.</p>
+				]]>	
+			</description>
+			<pubDate>Thurs, 22 Feb 2024 12:00:00 +0500</pubDate>
+		</item>
 		
 		<item>
 			<title>New page on remote resources</title>


### PR DESCRIPTION
Having a single page to cover all three topics was becoming unwieldy. This pull request breaks out page break markers, page list, and page source identification and adds a separate overview to cover how they relate to each other.

It also expands the frequently asked questions to cover a number of issues that have been raised recently, such as not putting page breaks in headings, how to identify the source if it lacks a unique identifier, giving preference to `pageBreakSource`, etc.

 