### PR TITLE
Fix validation topics index

### DIFF
--- a/js/topics/en.js
+++ b/js/topics/en.js
@@ -89,8 +89,8 @@ var topic_list = [
 					{
 						'id': 'epub-val-overview',
 						'href': 'validation/overview.html',
-						'title': 'Overview',
-						'subtitle': 'Overview of validation tools for EPUB publications.'
+						'title': 'Validation Process',
+						'subtitle': 'Overview of the validation process and tools and for EPUB publications.'
 					},
 					{
 						'id': 'epub-val-epubcheck',
@@ -101,7 +101,7 @@ var topic_list = [
 					{
 						'id': 'epub-val-ace',
 						'href': 'validation/ace.html',
-						'title': 'Ace',
+						'title': 'Ace by DAISY',
 						'subtitle': 'How to use the Ace checker to find accessibility issues.'
 					},
 					{

--- a/publishing/docs/epub/validation/index.html
+++ b/publishing/docs/epub/validation/index.html
@@ -8,8 +8,7 @@
 		<script>
 			var page_info = {
 				'isIndex': true,
-				'root_id': 'epub',
-				'sub_id': 'validation'
+				'root_id': 'epub-validation'
 			};
 		</script>
 		<script src="/js/init.js"></script>
@@ -17,14 +16,6 @@
 	
 	<body>
 		<main>
-			<nav role="doc-toc" aria-label="Table of contents" id="toc">
-				<ol>
-					<li id="validation-overview"><a href="overview.html">Validation Process</a></li>
-					<li id="validation-epubcheck"><a href="epubcheck.html">EPUBCheck</a></li>
-					<li id="validation-ace"><a href="ace.html">Ace by DAISY</a></li>
-					<li id="validation-smart"><a href="smart.html">Ace SMART</a></li>
-				</ol>
-			</nav>
 		</main>
 	</body>
 </html>


### PR DESCRIPTION
Fixes the id to search for so the full list of epub topics doesn't appear, and removes the old hard-coded links from the index.html file.

Fixes #80