### PR TITLE
Fix typo in code example

### DIFF
--- a/publishing/docs/navigation/pagebreaks.html
+++ b/publishing/docs/navigation/pagebreaks.html
@@ -189,7 +189,7 @@
 				<p>To hide the page number from visual
 					viewing, the <code>aria-label</code> attribute can be used to identify the number.</p>
 				
-				<pre id="expl-pb-02-src" class="prettyprint linenums"><code>&lt;span role="doc-pagebreak" id="pg5" aria-label="5"/&lt;</code></pre>
+				<pre id="expl-pb-02-src" class="prettyprint linenums"><code>&lt;span role="doc-pagebreak" id="pg5" aria-label="5"/&gt;</code></pre>
 				
 				<p>The <code>id</code> attribute on the page break allows linking to the location from the page
 					list.</p>


### PR DESCRIPTION
Discovered a typo in the KB, on the "Page Break Markers" page, here is a fix.