### PR TITLE
Various minor fixes

### DIFF
--- a/css/kb.css
+++ b/css/kb.css
@@ -932,6 +932,10 @@ details.desc pre {
 }
 
 
+/* details patch for localization */
+div.details > div.details-body { display:none; }
+
+
 /* wcag explainer tables */
 
 table.sc-info {

--- a/js/details.js
+++ b/js/details.js
@@ -1,0 +1,7 @@
+
+$('body').on('click', 'div.details', function() {
+	var expanded = $(this).find('button').attr('aria-expanded');
+	$(this).find('button').attr('aria-expanded', expanded === 'false' ? 'true' : 'false');
+	$(this).find('span.status').html(expanded === 'true' ? '▶' : '▼');
+	$(this).find('div.details-body').toggle();
+});

--- a/js/init.js
+++ b/js/init.js
@@ -52,6 +52,7 @@ function KB() {
 	this.noTopLink = page_info.hasOwnProperty('noTopLink') ? true: false;
 	this.noTitle = page_info.hasOwnProperty('noTitle') ? true: false;
 	this.noFooter = (page_info.hasOwnProperty('footer') && !page_info['footer']) ? true : false;
+	this.details = (page_info.hasOwnProperty('details') && page_info['details']) ? true : false;
 	
 	this.title = document.title;
 }
@@ -76,6 +77,11 @@ KB.prototype.initializePage = function (type) {
 		this.writeHeadTag('js', '/js/prettify.js');
 		this.writeGoogleAnalytics();
 		this.writeHeadTag('favicon', null, null);
+		
+		if (this.details) {
+			this.writeHeadTag('js', 'https://code.jquery.com/jquery-2.2.4.min.js', { 'integrity': 'sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=', 'crossorigin': 'anonymous'});
+			this.writeHeadTag('js', '/js/details.js', {'defer': 'true'});
+		}
 	}
 	else {
 		this.host = 'ace';

--- a/js/lang/en/sc.json
+++ b/js/lang/en/sc.json
@@ -260,6 +260,21 @@
 		"name": "Section Headings",
 		"level": "AAA"
 	},
+	"2.4.11": {
+		"id": "focus-not-obscured-minimum",
+		"name": "Focus Not Obscured (Minimum)",
+		"level": "AA"
+	},
+	"2.4.12": {
+		"id": "focus-not-obscured-enhanced",
+		"name": "Focus Not Obscured (Enhanced)",
+		"level": "AAA"
+	},
+	"2.4.13": {
+		"id": "focus-appearance",
+		"name": "Focus Appearance",
+		"level": "AAA"
+	},
 	"2.5.1": {
 		"id": "pointer-gestures",
 		"name": "Pointer Gestures",
@@ -289,6 +304,16 @@
 		"id": "concurrent-input-mechanisms",
 		"name": "Concurrent Input Mechanisms",
 		"level": "AAA"
+	},
+	"2.5.7": {
+		"id": "dragging-movements",
+		"name": "Dragging Movements",
+		"level": "AA"
+	},
+	"2.5.8": {
+		"id": "target-size-minimum",
+		"name": "Target Size (Minimum)",
+		"level": "AA"
 	},
 	"3.1.1": {
 		"id": "language-of-page",
@@ -345,6 +370,11 @@
 		"name": "Change on Request",
 		"level": "AAA"
 	},
+	"3.2.6": {
+		"id": "consistent-help",
+		"name": "Consistent Help",
+		"level": "A"
+	},
 	"3.3.1": {
 		"id": "error-identification",
 		"name": "Error Identification",
@@ -373,6 +403,21 @@
 	"3.3.6": {
 		"id": "error-prevention-all",
 		"name": "Error Prevention (All)",
+		"level": "AAA"
+	},
+	"3.3.7": {
+		"id": "redundant-entry",
+		"name": "Redundant Entry",
+		"level": "A"
+	},
+	"3.3.8": {
+		"id": "accessible-authentication",
+		"name": "Accessible Authentication (Minimum)",
+		"level": "AA"
+	},
+	"3.3.9": {
+		"id": "accessible-authentication-no-exception",
+		"name": "Accessible Authentication ('Enhanced')",
 		"level": "AAA"
 	},
 	"4.1.1": {

--- a/js/lang/en/sc.json
+++ b/js/lang/en/sc.json
@@ -411,12 +411,12 @@
 		"level": "A"
 	},
 	"3.3.8": {
-		"id": "accessible-authentication",
+		"id": "accessible-authentication-minimum",
 		"name": "Accessible Authentication (Minimum)",
 		"level": "AA"
 	},
 	"3.3.9": {
-		"id": "accessible-authentication-no-exception",
+		"id": "accessible-authentication-enhanced",
 		"name": "Accessible Authentication ('Enhanced')",
 		"level": "AAA"
 	},

--- a/publishing/docs/epub/validation/ace.html
+++ b/publishing/docs/epub/validation/ace.html
@@ -54,8 +54,10 @@
 				<section id="ace-lang">
 					<h4>Application Language</h4>
 					<p>When the Ace application is first run it starts with English as the default language. The
-						application can be localized so its interface and messages are in another language, however. (At
-						the time of writing, French, Spanish and Brazilian Portuguese are also available.)</p>
+						application can be localized so its interface and messages are in another language, however,
+						such as Japanese, Danish, Korean, and French. For the full list of supported languages, please
+						refer to the <a href="https://explore.transifex.com/idpf/epubcheck/">epubcheck transifex
+							localization project</a>.</p>
 					<p>To change the interface, click on the Settings button in the quick links on the left-hand side of
 						the application.</p>
 					<div class="note" role="note" aria-labelledby="lang-note-01">

--- a/publishing/docs/epub/validation/smart.html
+++ b/publishing/docs/epub/validation/smart.html
@@ -9,13 +9,10 @@
 			var page_info = {
 				'category':[ 'EPUB', 'Validation'],
 				'appliesTo':[ 'EPUB3', 'EPUB2'],
-				'addh4': true
+				'addh4': true,
+				'details': true
 			};</script>
 		<script src="/js/init.js"></script>
-		<script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
-		<style>
-			div.details > div.details-body { display:none; }
-		</style>
 	</head>
 	<body>
 		<main>
@@ -491,8 +488,5 @@
 				</ul>
 			</section>
 		</main>
-		<script>
-			$('body').on('click', 'div.details', function() { var expanded = $(this).find('button').attr('aria-expanded'); $(this).find('button').attr('aria-expanded', expanded === 'false' ? 'true' : 'false');$(this).find('span.status').html(expanded === 'true' ? '▶' : '▼');$(this).find('div.details-body').toggle(); });
-		</script>
 	</body>
 </html>

--- a/publishing/docs/metadata/schema.org/accessibilityFeature.html
+++ b/publishing/docs/metadata/schema.org/accessibilityFeature.html
@@ -117,7 +117,6 @@
 					<li><a href="accessibilityFeature/timingControl.html">timingControl</a></li>
 					<li><a href="accessibilityFeature/transcript.html">transcript</a></li>
 					<li><a href="accessibilityFeature/ttsMarkup.html">ttsMarkup</a></li>
-					<li><a href="accessibilityFeature/ttsMarkup.html">ttsMarkup</a></li>
 					<li><a href="accessibilityFeature/unknown.html">unknown</a></li>
 					<li><a href="accessibilityFeature/unlocked.html">unlocked</a></li>
 					<li><a href="accessibilityFeature/verticalWriting.html">verticalWriting</a></li>

--- a/publishing/docs/wcag/accessible-authentication-no-exception.html
+++ b/publishing/docs/wcag/accessible-authentication-no-exception.html
@@ -2,9 +2,9 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
-		<title>Accessible Authentication (No Exception)</title>
+		<title>Accessible Authentication (Enhanced)</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="description" content="Explainer for success criterion 3.3.8 Accessible Authentication (No Exception)">
+		<meta name="description" content="Explainer for success criterion 3.3.9 Accessible Authentication (Enhanced)">
 		<script>
 			var page_info = {
 				'category': ['Conformance', 'WCAG'],
@@ -29,7 +29,7 @@
 					</tr>
 					<tr>
 						<th>Number:</th>
-						<td>3.3.8</td>
+						<td>3.3.9</td>
 					</tr>
 					<tr>
 						<th>Level:</th>
@@ -58,8 +58,8 @@
 						<th id="guidance">Guidance:</th>
 						<td class="docs">
 							<ul>
-								<li><a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-no-exception.html">Understanding Success Criterion 3.3.8</a></li>
-								<li><a href="https://www.w3.org/WAI/WCAG22/quickref/#accessible-authentication-no-exception">How to meet Success Criterion 3.3.8</a></li>
+								<li><a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced.html">Understanding Success Criterion 3.3.9</a></li>
+								<li><a href="https://www.w3.org/WAI/WCAG22/quickref/#accessible-authentication-enhanced">How to meet Success Criterion 3.3.9</a></li>
 							</ul>
 						</td>
 					</tr>

--- a/publishing/docs/wcag/accessible-authentication.html
+++ b/publishing/docs/wcag/accessible-authentication.html
@@ -2,9 +2,9 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
-		<title>Accessible Authentication</title>
+		<title>Accessible Authentication (Minimum)</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="description" content="Explainer for success criterion 3.3.7 Accessible Authentication">
+		<meta name="description" content="Explainer for success criterion 3.3.8 Accessible Authentication (Minimum)">
 		<script>
 			var page_info = {
 				'category': ['Conformance', 'WCAG'],
@@ -29,7 +29,7 @@
 					</tr>
 					<tr>
 						<th>Number:</th>
-						<td>3.3.7</td>
+						<td>3.3.8</td>
 					</tr>
 					<tr>
 						<th>Level:</th>
@@ -60,8 +60,8 @@
 						<th id="guidance">Guidance:</th>
 						<td class="docs">
 							<ul>
-								<li><a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication.html">Understanding Success Criterion 3.3.7</a></li>
-								<li><a href="https://www.w3.org/WAI/WCAG22/quickref/#accessible-authentication">How to meet Success Criterion 3.3.7</a></li>
+								<li><a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html">Understanding Success Criterion 3.3.8</a></li>
+								<li><a href="https://www.w3.org/WAI/WCAG22/quickref/#accessible-authentication-minimum">How to meet Success Criterion 3.3.8</a></li>
 							</ul>
 						</td>
 					</tr>

--- a/publishing/docs/wcag/contrast-enhanced.html
+++ b/publishing/docs/wcag/contrast-enhanced.html
@@ -8,14 +8,11 @@
 		<script>
 			var page_info = {
 				'category': ['Conformance', 'WCAG'],
-				'appliesTo': ['Audiobooks*','EPUB3','EPUB2']
+				'appliesTo': ['Audiobooks*','EPUB3','EPUB2'],
+				'details': true
 			};
 		</script>
 		<script src="/js/init.js"></script>
-		<script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
-		<style>
-			div.details > div.details-body { display:none; }
-		</style>
 	</head>
 	<body>
 		<main>
@@ -131,8 +128,5 @@
 				</ul>
 			</section>
 		</main>
-		<script>
-			$('body').on('click', 'div.details', function() { var expanded = $(this).find('button').attr('aria-expanded'); $(this).find('button').attr('aria-expanded', expanded === 'false' ? 'true' : 'false');$(this).find('span.status').html(expanded === 'true' ? '▶' : '▼');$(this).find('div.details-body').toggle(); });
-		</script>
 	</body>
 </html>

--- a/publishing/docs/wcag/contrast-minimum.html
+++ b/publishing/docs/wcag/contrast-minimum.html
@@ -8,14 +8,11 @@
 		<script>
 			var page_info = {
 				'category': ['Conformance', 'WCAG'],
-				'appliesTo': ['Audiobooks*','EPUB3','EPUB2']
+				'appliesTo': ['Audiobooks*','EPUB3','EPUB2'],
+				'details': true
 			};
 		</script>
 		<script src="/js/init.js"></script>
-		<script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
-		<style>
-			div.details > div.details-body { display:none; }
-		</style>
 	</head>
 	<body>
 		<main>
@@ -130,8 +127,5 @@
 				</ul>
 			</section>
 		</main>
-		<script>
-			$('body').on('click', 'div.details', function() { var expanded = $(this).find('button').attr('aria-expanded'); $(this).find('button').attr('aria-expanded', expanded === 'false' ? 'true' : 'false');$(this).find('span.status').html(expanded === 'true' ? '▶' : '▼');$(this).find('div.details-body').toggle(); });
-		</script>
 	</body>
 </html>

--- a/publishing/docs/wcag/index.html
+++ b/publishing/docs/wcag/index.html
@@ -272,13 +272,13 @@
 						<a href="error-prevention-all.html">3.3.6 Error Prevention (All)</a>
 					</li>
 					<li>
-						<a href="accessible-authentication.html">3.3.7 Accessible Authentication</a>
+						<a href="redundant-entry.html">3.3.7 Redundant Entry</a>
 					</li>
 					<li>
-						<a href="accessible-authentication-no-exception.html">3.3.8 Accessible Authentication (No Exception)</a>
+						<a href="accessible-authentication.html">3.3.8 Accessible Authentication (Minimum)</a>
 					</li>
 					<li>
-						<a href="redundant-entry.html">3.3.9 Redundant Entry</a>
+						<a href="accessible-authentication-no-exception.html">3.3.9 Accessible Authentication (Enhanced)</a>
 					</li>
 					<li>
 						<a href="parsing.html">4.1.1 Parsing</a>

--- a/publishing/docs/wcag/motion-actuation.html
+++ b/publishing/docs/wcag/motion-actuation.html
@@ -8,14 +8,11 @@
 		<script>
 			var page_info = {
 				'category': ['Conformance', 'WCAG'],
-				'appliesTo': ['Audiobooks*','EPUB3','EPUB2']
+				'appliesTo': ['Audiobooks*','EPUB3','EPUB2'],
+				'details': true
 			};
 		</script>
 		<script src="/js/init.js"></script>
-		<script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
-		<style>
-			div.details > div.details-body { display:none; }
-		</style>
 	</head>
 	<body>
 		<main>
@@ -113,8 +110,5 @@
 					Refer to the <a href="#guidance">WCAG guidance documents</a> for additional information.</p>
 			</section>
 		</main>
-		<script>
-			$('body').on('click', 'div.details', function() { var expanded = $(this).find('button').attr('aria-expanded'); $(this).find('button').attr('aria-expanded', expanded === 'false' ? 'true' : 'false');$(this).find('span.status').html(expanded === 'true' ? '▶' : '▼');$(this).find('div.details-body').toggle(); });
-		</script>
 	</body>
 </html>

--- a/publishing/docs/wcag/non-text-content.html
+++ b/publishing/docs/wcag/non-text-content.html
@@ -8,14 +8,11 @@
 		<script>
 			var page_info = {
 				'category': ['Conformance', 'WCAG'],
-				'appliesTo': ['Audiobooks*','EPUB3','EPUB2']
+				'appliesTo': ['Audiobooks*','EPUB3','EPUB2'],
+				'details': true
 			};
 		</script>
 		<script src="/js/init.js"></script>
-		<script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
-		<style>
-			div.details > div.details-body { display:none; }
-		</style>
 	</head>
 	<body>
 		<main>
@@ -227,8 +224,5 @@
 				</ul>
 			</section>
 		</main>
-		<script>
-			$('body').on('click', 'div.details', function() { var expanded = $(this).find('button').attr('aria-expanded'); $(this).find('button').attr('aria-expanded', expanded === 'false' ? 'true' : 'false');$(this).find('span.status').html(expanded === 'true' ? '▶' : '▼');$(this).find('div.details-body').toggle(); });
-		</script>
 	</body>
 </html>

--- a/publishing/docs/wcag/target-size-enhanced.html
+++ b/publishing/docs/wcag/target-size-enhanced.html
@@ -8,14 +8,11 @@
 		<script>
 			var page_info = {
 				'category': ['Conformance', 'WCAG'],
-				'appliesTo': ['Audiobooks*','EPUB3','EPUB2']
+				'appliesTo': ['Audiobooks*','EPUB3','EPUB2'],
+				'details': true
 			};
 		</script>
 		<script src="/js/init.js"></script>
-		<script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
-		<style>
-			div.details > div.details-body { display:none; }
-		</style>
 	</head>
 	<body>
 		<main>
@@ -132,8 +129,5 @@
 				</ul>
 			</section>
 		</main>
-		<script>
-			$('body').on('click', 'div.details', function() { var expanded = $(this).find('button').attr('aria-expanded'); $(this).find('button').attr('aria-expanded', expanded === 'false' ? 'true' : 'false');$(this).find('span.status').html(expanded === 'true' ? '▶' : '▼');$(this).find('div.details-body').toggle(); });
-		</script>
 	</body>
 </html>

--- a/publishing/docs/wcag/target-size-minimum.html
+++ b/publishing/docs/wcag/target-size-minimum.html
@@ -8,14 +8,11 @@
 		<script>
 			var page_info = {
 				'category': ['Conformance', 'WCAG'],
-				'appliesTo': ['Audiobooks*','EPUB3','EPUB2']
+				'appliesTo': ['Audiobooks*','EPUB3','EPUB2'],
+				'details': true
 			};
 		</script>
 		<script src="/js/init.js"></script>
-		<script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
-		<style>
-			div.details > div.details-body { display:none; }
-		</style>
 	</head>
 	<body>
 		<main>
@@ -122,8 +119,5 @@
 				</ul>
 			</section>
 		</main>
-		<script>
-			$('body').on('click', 'div.details', function() { var expanded = $(this).find('button').attr('aria-expanded'); $(this).find('button').attr('aria-expanded', expanded === 'false' ? 'true' : 'false');$(this).find('span.status').html(expanded === 'true' ? '▶' : '▼');$(this).find('div.details-body').toggle(); });
-		</script>
 	</body>
 </html>


### PR DESCRIPTION
This pull request fixes the following issues:

- it fixes the numbering and title changes that occurred WCAG 2.2 that were missed
- it adds the new WCAG 2.2 SC to the sc.json file (for transforming technique references)
- it removes a duplicate entry for ttsMarkup from the accessibility features list
- it adds mention of epubcheck being available in Japanese and links to the transifex project so people can look up current support
- it moves the code to replace details elements with div/button equivalents to the init script (to work around the translation problems the element is causing)