### PR TITLE
Fix broken links

### DIFF
--- a/publishing/docs/metadata/schema.org/accessibilityFeature/MathML.html
+++ b/publishing/docs/metadata/schema.org/accessibilityFeature/MathML.html
@@ -66,7 +66,7 @@
 				<p>The <code>MathML</code> value is often paired with the <a href="#describedMath">describedMath
 					value</a> when fallback descriptions are provided.</p>
 				
-				<p>See the <a href="../../html/mathml.html">MathML knowledge base page</a> for more
+				<p>See the <a href="../../../html/mathml.html">MathML knowledge base page</a> for more
 					information.</p>
 				
 				<figure id="ex-mml">

--- a/publishing/docs/metadata/schema.org/accessibilityFeature/alternativeText.html
+++ b/publishing/docs/metadata/schema.org/accessibilityFeature/alternativeText.html
@@ -77,7 +77,7 @@
 					<pre id="ex-alt-02-src" class="prettyprint">&lt;img src="spacer.jpg" alt="" role="presentation" /></pre>
 				</figure>
 				
-				<p>See the <a href="../../html/images-desc.html">Image Descriptions knowledge base page</a> for more
+				<p>See the <a href="../../../html/images-desc.html">Image Descriptions knowledge base page</a> for more
 					information.</p>
 			</section>
 			

--- a/publishing/docs/metadata/schema.org/accessibilityFeature/longDescription.html
+++ b/publishing/docs/metadata/schema.org/accessibilityFeature/longDescription.html
@@ -66,7 +66,7 @@
 						>techniques for WCAG success criterion 1.1.1</a> for more information on when extended
 					descriptions are needed.</p>
 				
-				<p>See the <a href="../../html/images-desc.html">Image Descriptions knowledge base page</a> for more
+				<p>See the <a href="../../../html/images-desc.html">Image Descriptions knowledge base page</a> for more
 					information.</p>
 				
 				<figure id="ex-ld-01">

--- a/publishing/docs/metadata/schema.org/accessibilityFeature/pageBreakMarkers.html
+++ b/publishing/docs/metadata/schema.org/accessibilityFeature/pageBreakMarkers.html
@@ -65,7 +65,7 @@
 				<p>Page break markers are also added to digital publications without a static paginated source to
 					aid users in navigating the text.</p>
 				
-				<p>See the <a href="../../navigation/pagelist.html">page navigation knowledge base page</a> for
+				<p>See the <a href="../../../navigation/pagelist.html">page navigation knowledge base page</a> for
 					more information.</p>
 				
 				<figure id="ex-pbm">

--- a/publishing/docs/metadata/schema.org/accessibilityFeature/pageNavigation.html
+++ b/publishing/docs/metadata/schema.org/accessibilityFeature/pageNavigation.html
@@ -68,7 +68,7 @@
 					coordinate their locations with print users. In these cases, the <a href="#pageBreakMarkers"
 						><code>pageBreakMarkers</code></a> value is also set.</p>
 				
-				<p>See the <a href="../../navigation/pagelist.html">page navigation knowledge base page</a> for
+				<p>See the <a href="../../../navigation/pagelist.html">page navigation knowledge base page</a> for
 					more information.</p>
 				
 				<figure id="ex-pgl">

--- a/publishing/docs/metadata/schema.org/accessibilityFeature/readingOrder.html
+++ b/publishing/docs/metadata/schema.org/accessibilityFeature/readingOrder.html
@@ -70,7 +70,7 @@
 					elements and having to represent secondary content that spans two pages, but it is possible
 					for fixed layouts to have a logical reading progression if care is taken.</p>
 				
-				<p>See the <a href="../../html/order.html">logical reading order knowledge base page</a> for
+				<p>See the <a href="../../../html/order.html">logical reading order knowledge base page</a> for
 					more information.</p>
 			</section>
 			

--- a/publishing/docs/metadata/schema.org/accessibilityFeature/structuralNavigation.html
+++ b/publishing/docs/metadata/schema.org/accessibilityFeature/structuralNavigation.html
@@ -61,7 +61,7 @@
 					to quickly move through the different levels of the book without having to traverse the
 					table of contents.</p>
 				
-				<p>See the <a href="../../html/headings.html">HTML headings knowledge base page</a> for more
+				<p>See the <a href="../../../html/headings.html">HTML headings knowledge base page</a> for more
 					information.</p>
 				
 				<figure id="ex-sn-01">

--- a/publishing/docs/metadata/schema.org/accessibilityFeature/synchronizedAudioText.html
+++ b/publishing/docs/metadata/schema.org/accessibilityFeature/synchronizedAudioText.html
@@ -67,7 +67,7 @@
 				<p>Text and audio synchronization is typically provided using the SMIL language (e.g., in DAISY
 					talking books and EPUB 3 media overlays).</p>
 				
-				<p>See the <a href="../../sync-media/overlays.html">media overlays knowledge base page</a> for
+				<p>See the <a href="../../../sync-media/overlays.html">media overlays knowledge base page</a> for
 					more information.</p>
 				
 				<figure id="ex-sat">

--- a/publishing/docs/metadata/schema.org/accessibilityFeature/tableOfContents.html
+++ b/publishing/docs/metadata/schema.org/accessibilityFeature/tableOfContents.html
@@ -66,7 +66,7 @@
 					(e.g., includes at least all the top-level headings), otherwise it is incorrect to set this
 					value.</p>
 				
-				<p>See the <a href="../../navigation/toc.html">table of contents knowledge base page</a> for
+				<p>See the <a href="../../../navigation/toc.html">table of contents knowledge base page</a> for
 					more information.</p>
 				
 				<figure id="ex-toc">

--- a/publishing/docs/metadata/schema.org/accessibilityFeature/ttsMarkup.html
+++ b/publishing/docs/metadata/schema.org/accessibilityFeature/ttsMarkup.html
@@ -61,7 +61,7 @@
 					are spelled the same but sound different). The result is that it can be very difficult for
 					users who cannot see the text to understand what is being read out.</p>
 				
-				<p>The <a href="../../text-to-speech/ssml.html">SSML markup language</a> allows the phonetic
+				<p>The <a href="../../../text-to-speech/ssml.html">SSML markup language</a> allows the phonetic
 					renderings of words to be included in the markup of publications to improve rendering, for
 					example. PLS pronunciation lexicons similarly allow libraries of phonetic pronunciations to
 					be attached to HTML content.</p>


### PR DESCRIPTION
When the accessibility feature pages were split out and moved down a folder, some of the links out to other KB pages broke. This PR adds an extra "../" to the broken paths so they'll work again.