### PR TITLE
Remove support note for page breaks

### DIFF
--- a/publishing/docs/navigation/pagebreaks.html
+++ b/publishing/docs/navigation/pagebreaks.html
@@ -177,9 +177,10 @@
 				<h3>Explanation</h3>
 				
 				<p>If a digital publication is produced from the same workflow as a print document, page break
-					locations should be retained. Retaining the page break locations can allow assistive
+					locations should be retained. Retaining the page break locations, together with providing a
+					<a href="./pagelist.html">page list</a>, can allow assistive
 					technologies and reading systems to announce the current page users are on and also allow users
-					to move forward or backward by page. (This functionality is not yet available for EPUBs.)</p>
+					to move forward or backward by page.</p>
 				
 				<p>Page break locations can be added to the markup using <code>span</code> and <code>div</code>
 					tags with a <code>role</code> attribute set to the value <code>doc-pagebreak</code>.</p>


### PR DESCRIPTION
The functionality described usually comes through the page list, so the support statement just added unnecessary confusion. Better to remove it and note the need for both.