### PR TITLE
Fix "the a" typo

### DIFF
--- a/publishing/docs/html/dpub-aria/doc-abstract.html
+++ b/publishing/docs/html/dpub-aria/doc-abstract.html
@@ -49,7 +49,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-abstract</code> inherits its semantics from the a <a
+				<p><code>doc-abstract</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#section">section role</a> (i.e., it represents a container
 					of related content, but is not a landmark).</p>
 			</section>

--- a/publishing/docs/html/dpub-aria/doc-backlink.html
+++ b/publishing/docs/html/dpub-aria/doc-backlink.html
@@ -40,7 +40,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-baclink</code> inherits its semantics from the a <a
+				<p><code>doc-baclink</code> inherits its semantics from the <a
 					href="https://www.w3.org/TR/wai-aria/#link">link role</a>.</p>
 			</section>
 

--- a/publishing/docs/html/dpub-aria/doc-biblioref.html
+++ b/publishing/docs/html/dpub-aria/doc-biblioref.html
@@ -38,7 +38,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-biblioref</code> inherits its semantics from the a <a
+				<p><code>doc-biblioref</code> inherits its semantics from the <a
 					href="https://www.w3.org/TR/wai-aria/#link">link role</a>.</p>
 			</section>
 

--- a/publishing/docs/html/dpub-aria/doc-colophon.html
+++ b/publishing/docs/html/dpub-aria/doc-colophon.html
@@ -52,7 +52,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-colophon</code> inherits its semantics from the a <a
+				<p><code>doc-colophon</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#section">section role</a> (i.e., it represents a container
 					of related content, but is not a landmark).</p>
 			</section>

--- a/publishing/docs/html/dpub-aria/doc-cover.html
+++ b/publishing/docs/html/dpub-aria/doc-cover.html
@@ -37,7 +37,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-cover</code> inherits its semantics from the a <a
+				<p><code>doc-cover</code> inherits its semantics from the <a
 					href="https://www.w3.org/TR/wai-aria/#img">img role</a>.</p>
 			</section>
 

--- a/publishing/docs/html/dpub-aria/doc-credit.html
+++ b/publishing/docs/html/dpub-aria/doc-credit.html
@@ -43,7 +43,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-credit</code> inherits its semantics from the a <a
+				<p><code>doc-credit</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#section">section role</a> (i.e., it represents a container
 					of related content, but is not a landmark).</p>
 			</section>

--- a/publishing/docs/html/dpub-aria/doc-dedication.html
+++ b/publishing/docs/html/dpub-aria/doc-dedication.html
@@ -39,7 +39,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-dedication</code> inherits its semantics from the a <a
+				<p><code>doc-dedication</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#section">section role</a> (i.e., it represents a container
 					of related content, but is not a landmark).</p>
 			</section>

--- a/publishing/docs/html/dpub-aria/doc-endnote.html
+++ b/publishing/docs/html/dpub-aria/doc-endnote.html
@@ -64,7 +64,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-endnote</code> inherits its semantics from the a <a
+				<p><code>doc-endnote</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#listitem">listitem role</a>.</p>
 			</section>
 

--- a/publishing/docs/html/dpub-aria/doc-epigraph.html
+++ b/publishing/docs/html/dpub-aria/doc-epigraph.html
@@ -42,7 +42,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-epigraph</code> inherits its semantics from the a <a
+				<p><code>doc-epigraph</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#section">section role</a> (i.e., it represents a container
 					of related content, but is not a landmark).</p>
 			</section>

--- a/publishing/docs/html/dpub-aria/doc-example.html
+++ b/publishing/docs/html/dpub-aria/doc-example.html
@@ -58,7 +58,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-example</code> inherits its semantics from the a <a
+				<p><code>doc-example</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#section">section role</a> (i.e., it represents a container
 					of related content, but is not a landmark).</p>
 			</section>

--- a/publishing/docs/html/dpub-aria/doc-footnote.html
+++ b/publishing/docs/html/dpub-aria/doc-footnote.html
@@ -39,7 +39,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-footnote</code> inherits its semantics from the a <a
+				<p><code>doc-footnote</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#section">section role</a> (i.e., it represents a container
 					of related content, but is not a landmark).</p>
 			</section>

--- a/publishing/docs/html/dpub-aria/doc-glossref.html
+++ b/publishing/docs/html/dpub-aria/doc-glossref.html
@@ -39,7 +39,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-glossref</code> inherits its semantics from the a <a
+				<p><code>doc-glossref</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#link">link role</a>.</p>
 			</section>
 

--- a/publishing/docs/html/dpub-aria/doc-noteref.html
+++ b/publishing/docs/html/dpub-aria/doc-noteref.html
@@ -42,7 +42,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-noteref</code> inherits its semantics from the a <a
+				<p><code>doc-noteref</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#link">link role</a>.</p>
 			</section>
 

--- a/publishing/docs/html/dpub-aria/doc-notice.html
+++ b/publishing/docs/html/dpub-aria/doc-notice.html
@@ -52,7 +52,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-notice</code> inherits its semantics from the a <a
+				<p><code>doc-notice</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#note">note role</a>.</p>
 			</section>
 

--- a/publishing/docs/html/dpub-aria/doc-pagebreak.html
+++ b/publishing/docs/html/dpub-aria/doc-pagebreak.html
@@ -54,7 +54,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-pagebreak</code> inherits its semantics from the a <a
+				<p><code>doc-pagebreak</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#separator">separator role</a>.</p>
 			</section>
 

--- a/publishing/docs/html/dpub-aria/doc-pullquote.html
+++ b/publishing/docs/html/dpub-aria/doc-pullquote.html
@@ -50,7 +50,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-pullquote</code> inherits its semantics from the a <a
+				<p><code>doc-pullquote</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#none">none role</a> (i.e., it is presentational).</p>
 			</section>
 

--- a/publishing/docs/html/dpub-aria/doc-qna.html
+++ b/publishing/docs/html/dpub-aria/doc-qna.html
@@ -44,7 +44,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-qna</code> inherits its semantics from the a <a
+				<p><code>doc-qna</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#section">section role</a> (i.e., it represents a container
 					of related content, but is not a landmark).</p>
 			</section>

--- a/publishing/docs/html/dpub-aria/doc-subtitle.html
+++ b/publishing/docs/html/dpub-aria/doc-subtitle.html
@@ -39,7 +39,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-subtitle</code> inherits its semantics from the a <a
+				<p><code>doc-subtitle</code> inherits its semantics from the <a
 						href="https://www.w3.org/TR/wai-aria/#sectionhead">sectionhead role</a>.</p>
 			</section>
 

--- a/publishing/docs/html/dpub-aria/doc-tip.html
+++ b/publishing/docs/html/dpub-aria/doc-tip.html
@@ -39,7 +39,7 @@
 			<section id="aria">
 				<h3>Relation to ARIA</h3>
 
-				<p><code>doc-tip</code> inherits its semantics from the a <a href="https://www.w3.org/TR/wai-aria/#note"
+				<p><code>doc-tip</code> inherits its semantics from the <a href="https://www.w3.org/TR/wai-aria/#note"
 						>note role</a>.</p>
 			</section>
 


### PR DESCRIPTION
Fixes the copy/paste addition of a grammatically incorrect "a" from the role inheritance sections.