### PR TITLE
Clarify the quoted definition comes from onix

### DIFF
--- a/publishing/docs/metadata/onix.html
+++ b/publishing/docs/metadata/onix.html
@@ -384,8 +384,9 @@
 							MathML. Semantic MathML is preferred but Presentational MathML is acceptable.</p>
 					</blockquote>
 					
-					<p>There is no support for Semantic MathML in web user agents, such as EPUB reading systems, so
-						providing Presentational MathML is generally all that is possible.</p>
+					<p>Although the definition states that Semantic MathML is preferred, there is no support for 
+						Semantic MathML in web user agents, such as EPUB reading systems, so providing Presentational
+						MathML is generally all that is possible.</p>
 					
 					<pre id="ex-12-src" class="prettyprint linenums"><code>&lt;ProductFormFeature>
  &lt;ProductFormFeatureType>09&lt;/ProductFormFeatureType>


### PR DESCRIPTION
This pull request clarifies that the preference for semantic mathml is the onix definition.