### PR TITLE
Remove mathml caution

### DIFF
--- a/publishing/docs/html/mathml.html
+++ b/publishing/docs/html/mathml.html
@@ -16,15 +16,6 @@
 
 	<body>
 		<main>
-			<div class="warning" role="note" aria-labelledby="use-warn">
-				<p class="label" id="use-warn">Caution</p>
-				<p>A solution for MathML that works in all reading systems does not currently exist. The techniques
-					presented on this page will continue to be updated as new information becomes available.</p>
-				<p>Refer to the <a 
-					href="https://daisy.github.io/transitiontoepub/best-practices/mathML/mathMLBestPractices.html">Best
-					Practices for Authoring MathML in EPUB</a> guide for the latest information.</p>
-			</div>
-
 			<section id="summary">
 				<h3>Summary</h3>
 

--- a/publishing/docs/new/feed.xml
+++ b/publishing/docs/new/feed.xml
@@ -5,9 +5,21 @@
 		<description>Recent updates to the DAISY Accessible Publishing KB</description>
 		<link>https://kb.daisy.org/publishing/docs</link>
 		<copyright>2024 DAISY. All rights reserved</copyright>
-		<lastBuildDate>Thur, 19 Sept 2024 00:01:00 +0500</lastBuildDate>
-		<pubDate>Thur, 19 Sept 2024 12:00:00 +0500</pubDate>
+		<lastBuildDate>Wed, 11 Dec 2024 00:01:00 +0500</lastBuildDate>
+		<pubDate>Wed, 11 Dec 2024 12:00:00 +0500</pubDate>
 		<ttl>1440</ttl>
+		
+		<item>
+			<title>MathML caution removed</title>
+			<link>https://kb.daisy.org/publishing/docs/html/mathml.html</link>
+			<description>
+				<![CDATA[
+				<p>The caution about using MathML has been removed as support for MathML rendering continues to
+					improve.</p>
+				]]>	
+			</description>
+			<pubDate>Wed, 11 Dec 2024 12:00:00 +0500</pubDate>
+		</item>
 		
 		<item>
 			<title>New pages for QR codes</title>


### PR DESCRIPTION
Removing the caution from the top of the page. The link to the techniques document remains in the note at the end of the explanation section.