### PR TITLE
Switch "do" to "do not" for reusing publication title as each html document title

### DIFF
--- a/publishing/docs/html/title.html
+++ b/publishing/docs/html/title.html
@@ -60,7 +60,7 @@
 				
 				<p>Providing meaningful titles for all the documents in a publication allows users to quickly identify
 					where they are, and in which work. Include as specific information as possible about the content (e.g.,
-					the primary heading of the section the document contains). Do use the title of the work as the title
+					the primary heading of the section the document contains). Do not use the title of the work as the title
 					for every document.</p>
 					
 				<p>Assistive technologies typically announce the title of each document when it is first loaded in a user agent,


### PR DESCRIPTION
Fixes #149 