### PR TITLE
Fix uses of "topic"

### DIFF
--- a/publishing/docs/contribute/index.html
+++ b/publishing/docs/contribute/index.html
@@ -123,14 +123,14 @@ var page_info = {
 };
 &lt;/script></pre>
 					
-					<p>The <code>topic</code> field <strong>must</strong> be the uppercase name of the directory where
-						you are creating the page. For example, if you are adding a new page to the html directory, you
+					<p>The <code>category</code> field <strong>must</strong> be the uppercase name of the directory where
+						you are creating the page. For example, if you are adding a new page to the <code>html</code> directory, you
 						would set the field to:</p>
 					
 					<pre id="info-ex-02" class="prettyprint linenums">'category': 'HTML',</pre>
 					
-					<p>If you are creating a new subdirectory for your page(s), you will need to make an array of values
-						for the topic. For example, pages in the <code>html/dpub-aria</code> directory include an array
+					<p>If you are creating a new subdirectory for your page(s), you will need to make an array of values.
+						For example, pages in the <code>html/dpub-aria</code> directory include an array
 						like this:</p>
 					
 					<pre id="info-ex-03" class="prettyprint linenums">'category': ['html', 'dpub-aria'],</pre>


### PR DESCRIPTION
Switches "topic" to "category" for the page metadata. Removes a reference to "topic" where it's easy to confuse with setting the category.