### PR TITLE
Localize searching

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -279,6 +279,12 @@ KB.prototype.generateHeader = function () {
 	
 	var search_box = document.createElement('div');
 		search_box.setAttribute('class', 'gcse-searchbox-only');
+		search_box.setAttribute('data-lr', 'lang_'  + this.lang);
+		search_box.setAttribute('data-gl', 'lang_'  + this.lang);
+		
+		if (this.lang !== 'en') {
+			search_box.setAttribute('data-resultsUrl', '/publishing/' + this.lang + '/search/');
+		}
 	
 	search.appendChild(search_box);
 	header.appendChild(search);


### PR DESCRIPTION
Improves the custom search results for Japanese but we might still need to create a separate search engine for the translation as it appears there are interface components that can only be localized to the language in the control panel.