### PR TITLE
Increase line height for topic headings

### DIFF
--- a/css/kb.css
+++ b/css/kb.css
@@ -53,6 +53,7 @@ h2 {
 	padding: 0.5em 0.7em 0 0.7em;
 	margin: 0 0 6rem 1.5rem;
 	letter-spacing: 0.125rem;
+	line-height: 4rem;
 }
 
 h2.noCategory {


### PR DESCRIPTION
Prevent wrapped words from being too close together.