### PR TITLE
Update priority of extended description mechanisms

### DIFF
--- a/publishing/docs/html/images-desc.html
+++ b/publishing/docs/html/images-desc.html
@@ -48,6 +48,28 @@
     alt="Accessible EPUB 3 - First Edition" /></code></pre>
 				</figure>
 				
+				<figure id="ex-03">
+					<figcaption>
+						<div class="label">Example &#8212; Extended description via hyperlink</div>
+						<p>The following example uses simple hyperlinks to link to a description in a separate file.
+							The <code>aria-details</code> attribute is used to associate the image with the 
+							link to the description.</p>
+					</figcaption>
+					<pre id="ex-03-src" class="prettyprint linenums"><code>&lt;figure id="fig-01">
+   &lt;img
+      src="graphics/water-cycle.jpg"
+      alt="The hydrologic cycle, showing the 
+        circular nature of the process as water 
+        evaporates from a body of water and 
+        eventually returns to it"
+      aria-details="cycle-desc"/>
+   &lt;figcaption>
+     The hydrologic cycle.
+     &lt;a id="cycle-desc" href="desc/fig-01.html">Description&lt;/a>
+   &lt;/figcaption>
+&lt;/figure></code></pre>
+				</figure>
+				
 				<figure id="ex-02">
 					<figcaption>
 						<div class="label">Example &#8212; Extended description in <code>details</code></div>
@@ -77,24 +99,6 @@
       A large body of water &#8230;
    &lt;/p>
 &lt;/details></code></pre>
-				</figure>
-				
-				<figure id="ex-03">
-					<figcaption>
-						<div class="label">Example &#8212; Extended description via hyperlink</div>
-						<p>The following example uses simple hyperlinks to link to a description in a separate file.</p>
-					</figcaption>
-					<pre id="ex-03-src" class="prettyprint linenums"><code>&lt;figure id="fig-01">
-   &lt;img
-      src="graphics/water-cycle.jpg"
-      alt="The hydrologic cycle, showing the 
-        circular nature of the process as water 
-        evaporates from a body of water and 
-        eventually returns to it"/>
-   &lt;figcaption>
-     The hydrologic cycle. &lt;a href="desc/fig-01.html">Description&lt;/a>
-   &lt;/figcaption>
-&lt;/figure></code></pre>
 				</figure>
 				
 				<figure id="ex-04">
@@ -155,26 +159,23 @@
 			<section id="faq">
 				<h3>Frequently Asked Questions</h3>
 				<dl>
-					<dt id="faq-001">Why link to visible descriptions?</dt>
+					<dt id="faq-001">Why do I need to use <code>aria-details</code>?</dt>
 					<dd>
-						<p>Even though a description is a visible part of the current page, linking to it provides a
-							programmatic means for users of assistive technologies to rapidly access the description without
-							having to hunt through the page content.</p>
+						<p>Although similar in purpose to the <code>aria-describedby</code> attribute,
+							the <code>aria-details</code> attribute does not result in stringified content
+							(i.e., the user will be able to navigate the description, or link to it, as 
+							structured HTML).</p>
+						
+						<p>Also, even though a description may be near to its image, using <code>aria-details</code>
+							provides a programmatic means for users of assistive technologies to rapidly access
+							the description. Otherwise, the user might miss the description if, for example, the
+							link to it is at the end of a figure caption they do not read through.</p>
 					</dd>
 					
 					<dt id="faq-002">Why not <code>longdesc</code>?</dt>
 					<dd>
 						<p>The <code>longdesc</code> attribute is now considered an obsolete feature of HTML.</p>
 						<p>Although published as a separate extension of HTML by W3C, it is not supported in EPUB.</p>
-					</dd>
-					
-					<dt id="faq-003">Why <code>aria-details</code>?</dt>
-					<dd>
-						<p>Although similar in purpose to the <code>aria-describedby</code> attribute,
-							the <code>aria-details</code> attribute does not result in stringified content
-							(i.e., the user will be able to navigate the description as structured HTML).
-							The <code>aria-details</code> attribute allows a user to navigate to the content
-							of a <code>details</code> element, for example.</p>
 					</dd>
 					
 					<dt id="faq-004">When is a <code>figure</code> tag needed?</dt>
@@ -315,6 +316,34 @@
 						href="http://diagramcenter.org/best-practices-for-authoring-extended-descriptions.html">Best
 						Practices for Authoring Extended Descriptions in EPUB</a>.</p>
 				
+				<section id="hyperlinks">
+					<h4>Hyperlinks</h4>
+					
+					<p>Plain old hyperlinks are one of the most widely accessible ways to direct users to a
+						description. Adding an <code>aria-details</code> attribute to the image enables
+						assistive technologies to make the link available to the user when they encounter the
+						image instead of having to search for the link after.</p>
+					
+					<pre class="prettyprint linenums"><code>&lt;img src="crime-map.jpg" aria-details="gotham" alt="Crime in Gotham City">
+&lt;a id="gotham" href="crime-desc.xhtml">Description&lt;/a>
+</code></pre>
+					
+					<p>Note that a hyperlink does not always have to reference a description in another document;
+						descriptions might be included at the end of a section, like footnotes.</p>
+					
+					<p>In EPUB, when possible, the linked description should be in a file by itself to avoid issues
+						reaching the description (i.e., not all reading systems are able to locate the user properly 
+						when there are multiple descriptions in the same file). If there are many images, however,
+						adding each description to a separate file can bloat the spine (i.e., every description file
+						must be listed).</p>
+					
+					<p>An image can be used to minimize the appearance of the link, but EPUB some reading systems
+						have issues with image links (they cannot be activated).</p>
+					
+					<p>Despite these shortcomings, however, hyperlinks are one of the more reliable techniques
+						currently supported in EPUB.</p>
+				</section>
+				
 				<section id="details">
 					<h4>The <code>details</code> element</h4>
 					
@@ -335,33 +364,6 @@
 					
 					<p>Despite these shortcomings, this element is still one of the more reliable techniques currently
 						supported in EPUB.</p>
-				</section>
-				
-				<section id="hyperlinks">
-					<h4>Hyperlinks</h4>
-					
-					<p>Plain old hyperlinks are another of the most widely accessible way to provide a link to a
-						description.</p>
-					
-					<pre class="prettyprint linenums"><code>&lt;figure>
-	&lt;img src="crime-map.jpg" alt="Crime in Gotham City">
-	&lt;a href="crime-desc.xhtml">Description&lt;/a>
-&lt;/figure></code></pre>
-					
-					<p>Note that a hyperlink does not always have to reference a description in another document;
-						descriptions might be included at the end of a section, like footnotes.</p>
-					
-					<p>In EPUB, when possible, the linked description should be in a file by itself to avoid issues
-						reaching the description (i.e., not all reading systems are able to locate the user properly 
-						when there are multiple descriptions in the same file). If there are many images, however,
-						adding each description to a separate file can bloat the spine (i.e., every description file
-						must be listed).</p>
-					
-					<p>An image can be used to minimize the appearance of the link, but EPUB some reading systems
-						have issues with image links (they cannot be activated).</p>
-					
-					<p>Despite these shortcomings, however, hyperlinks are one of the more reliable techniques
-						currently supported in EPUB.</p>
 				</section>
 			</section>
 			

--- a/publishing/docs/html/images-desc.html
+++ b/publishing/docs/html/images-desc.html
@@ -324,7 +324,10 @@
 						assistive technologies to make the link available to the user when they encounter the
 						image instead of having to search for the link after.</p>
 					
-					<pre class="prettyprint linenums"><code>&lt;img src="crime-map.jpg" aria-details="gotham" alt="Crime in Gotham City">
+					<pre class="prettyprint linenums"><code>&lt;img src="crime-map.jpg"
+     aria-details="gotham"
+     alt="Crime in Gotham City">
+
 &lt;a id="gotham" href="crime-desc.xhtml">Description&lt;/a>
 </code></pre>
 					

--- a/publishing/docs/new/feed.xml
+++ b/publishing/docs/new/feed.xml
@@ -4,87 +4,34 @@
 		<title>DAISY Accessible Publishing Knowledge Base</title>
 		<description>Recent updates to the DAISY Accessible Publishing KB</description>
 		<link>https://kb.daisy.org/publishing/docs</link>
-		<copyright>2024 DAISY. All rights reserved</copyright>
-		<lastBuildDate>Wed, 11 Dec 2024 00:01:00 +0500</lastBuildDate>
-		<pubDate>Wed, 11 Dec 2024 12:00:00 +0500</pubDate>
+		<copyright>2025 DAISY. All rights reserved</copyright>
+		<lastBuildDate>Tue, 8 Jul 2025 00:01:00 +0500</lastBuildDate>
+		<pubDate>Tue, 8 Jul 2025 12:00:00 +0500</pubDate>
 		<ttl>1440</ttl>
 		
 		<item>
-			<title>MathML caution removed</title>
-			<link>https://kb.daisy.org/publishing/docs/html/mathml.html</link>
+			<title>Prioritizing links to image descriptions</title>
+			<link>https://kb.daisy.org/publishing/docs/html/images-desc.html</link>
 			<description>
 				<![CDATA[
-				<p>The caution about using MathML has been removed as support for MathML rendering continues to
-					improve.</p>
+				<p>The page on providing image descriptions has been updated to prioritize the current 
+					best practice of using the <code>aria-details</code> attribute to reference a hyperlink
+					to the description.</p>
 				]]>	
 			</description>
-			<pubDate>Wed, 11 Dec 2024 12:00:00 +0500</pubDate>
+			<pubDate>Tue, 8 Jul 2025 12:00:00 +0500</pubDate>
 		</item>
 		
 		<item>
-			<title>New pages for QR codes</title>
-			<link>https://kb.daisy.org/publishing/docs/html/images-qr.html</link>
+			<title>Knowledge base now available in Japanese</title>
+			<link>https://kb.daisy.org/publishing/ja/</link>
 			<description>
 				<![CDATA[
-				<p>Although QR codes are most often associated with getting people from physical to digital media,
-					they are starting to appear in digital publications. QR codes can be helpful for devices that
-					are not connected to the internet, but they need to be created accessibly to be useful to the
-					greatest number of readers. The knowledge base now includes a page covering best practices for
-					<a href="https://kb.daisy.org/publishing/docs/html/images-qr.html">QR codes</a>.</p>
+				<p>The knowledge base has been translated into Japanese. It is also available to Japanese users in 
+				the Ace by DAISY validation tool.</p>
 				]]>	
 			</description>
-			<pubDate>Thur, 19 Sept 2024 12:00:00 +0500</pubDate>
-		</item>
-		
-		<item>
-			<title>New pages for accessibility features</title>
-			<link>https://kb.daisy.org/publishing/docs/metadata/schema.org/accessibilityFeature.html</link>
-			<description>
-				<![CDATA[
-				<p>The knowledge base now includes separate pages for each of the schema.org 
-					<code>accessibilityFeature</code> values. As the list of these values grows, maintaining
-					their explanations in a single page has made discovering information about them more cumbersome.
-					By breaking them out into separate pages, each value now includes more information and examples.</p>
-				]]>	
-			</description>
-			<pubDate>Thur, 28 Mar 2024 12:00:00 +0500</pubDate>
-		</item>
-		
-		<item>
-			<title>New pages on setting the text direction</title>
-			<link>https://kb.daisy.org/publishing/docs/epub/dir.html</link>
-			<description>
-				<![CDATA[
-				<p>The knowledge base now includes two new pages covering the use of the <code>dir</code> attribute
-					to set the base direction for text in the <a 
-					href="https://kb.daisy.org/publishing/docs/epub/dir.html">package document</a> and in 
-					<a href="https://kb.daisy.org/publishing/docs/html/dir.html">HTML documents</a>.</p>
-				]]>	
-			</description>
-			<pubDate>Fri, 21 Mar 2024 12:00:00 +0500</pubDate>
-		</item>
-		
-		<item>
-			<title>Expanded guidance on page navigation</title>
-			<link>https://kb.daisy.org/publishing/docs/navigation/pagenav.html</link>
-			<description>
-				<![CDATA[
-				<p>The page on page navigation is now split in four:</p>
-				<ul>
-					<li><a href="https://kb.daisy.org/publishing/docs/navigation/pagenav.html">Overview</a></li>
-					<li><a href="https://kb.daisy.org/publishing/docs/navigation/pagebreaks.html">Page Breaks</a></li>
-					<li><a href="https://kb.daisy.org/publishing/docs/navigation/pagelist.html">Page List</a></li>
-					<li><a href="https://kb.daisy.org/publishing/docs/navigation/pagesrc.html">Page Source</a></li>
-				</ul>
-				<p>These pages provide additional context on their respective topics, as well as update and expand
-					on the examples and frequently asked questions.</p>
-				
-				<p>Some of the new issues covered include not adding page breaks to headings, how to identify the
-					source of pagination when the source does not have a unique identifier, and that preference
-					should now be given to the <code>pageBreakSource</code> property.</p>
-				]]>	
-			</description>
-			<pubDate>Thurs, 22 Feb 2024 12:00:00 +0500</pubDate>
+			<pubDate>Wed, 2 Apr 2025 12:00:00 +0500</pubDate>
 		</item>
 	</channel>
 </rss>

--- a/publishing/docs/new/index.html
+++ b/publishing/docs/new/index.html
@@ -55,7 +55,23 @@
 				<p>Changes are listed from most recent to oldest.</p>
 				
 				<div id="update-list">
-					<p>No updates yet for 2025.</p>
+					<dl class="value">
+						<dt>July 8, 2025 — Prioritizing links to image descriptions</dt>
+						<dd>
+							<p>The page on <a href="https://kb.daisy.org/publishing/docs/html/images-desc.html">providing
+									image descriptions</a> has been updated to prioritize the current best practice of
+								using the <code>aria-details</code> attribute to reference a hyperlink to the
+								description.</p>
+						</dd>
+						
+						<dt>April 2, 2025 — Knowledge base now available in Japanese</dt>
+						<dd>
+							<p>The knowledge base has been <a href="https://kb.daisy.org/publishing/ja/">translated into
+									Japanese</a>. It is also available to Japanese users in the <a 
+										href="https://daisy.org/activities/software/ace/">Ace by DAISY</a> validation 
+								tool.</p>
+						</dd>
+					</dl>
 				</div>
 				
 				<div id="archive">


### PR DESCRIPTION
This pull request moves the technique for using a hyperlink to link to the description ahead of the details element. It also adds aria-details to the example.