### PR TITLE
Updates to reflect changes to the DAISY image description best practices

### DIFF
--- a/publishing/docs/html/images-desc.html
+++ b/publishing/docs/html/images-desc.html
@@ -63,72 +63,6 @@ layout: publishing/pages/topic
 &lt;/figure></code></pre>
 	</figure>
 	
-	<figure id="ex-02">
-		<figcaption>
-			<div class="label">Example &#8212; Extended description in <code>details</code></div>
-			<p>The following example uses the HTML <code>details</code> element to create a description that is
-				collapsed from view by default. The <code>aria-details</code> attribute is used to associate
-				the image with the description.</p>
-		</figcaption>
-		<pre id="ex-02-src" class="prettyprint linenums"><code>&lt;figure id="fig-01">
-   &lt;figcaption>
-      The hydrologic cycle.
-   &lt;/figcaption>
-   &lt;img
-      src="graphics/water-cycle.jpg"
-      aria-details="fig-01-desc"
-      alt="The hydrologic cycle, showing the 
-        circular nature of the process as water 
-        evaporates from a body of water and 
-        eventually returns to it"/>
-&lt;/figure>
-&lt;details id="fig-01-desc">
-   &lt;summary>Description&lt;/summary>
-   &lt;p>
-      The diagram shows the processes of 
-      evaporation, condensation,
-      evapotranspiration, water storage
-      in ice and snow, and precipitation.
-      A large body of water &#8230;
-   &lt;/p>
-&lt;/details></code></pre>
-	</figure>
-	
-	<figure id="ex-04">
-		<figcaption>
-			<div class="label">Example &#8212; Hidden description</div>
-			<p>The following example uses the <code>aria-describedBy</code> attribute to link to a hidden
-				description, leaving no visual indication at all that a description is available.</p>
-			<p>Note that <strong>support for this attribute is poor in EPUB</strong>, particularly when referencing
-				hidden content. While valid, it may prevent any users from reaching the description, so should be
-				used with caution. The Open Web Platform is moving away from hidden content that can only be
-				accessed via assistive technologies.</p>
-			<p>This technique is not recommended if the description contains structured markup like tables or
-				lists, as all tagging is stripped and only the text content read to users.</p>
-		</figcaption>
-		<pre id="ex-04-src" class="prettyprint linenums"><code>&lt;figure id="fig-01">
-   &lt;img
-      src="graphics/water-cycle.jpg"
-      alt="The hydrologic cycle, showing the 
-        circular nature of the process as water 
-        evaporates from a body of water and 
-        eventually returns to it"
-      aria-describedby="desc01"/>
-   &lt;figcaption>
-     The hydrologic cycle.
-     &lt;aside id="desc01" hidden="hidden">
-        &lt;p>
-           The diagram shows the processes of 
-           evaporation, condensation,
-           evapotranspiration, water storage
-           in ice and snow, and precipitation.
-           A large body of water &#8230;
-        &lt;/p>
-     &lt;/aside>
-   &lt;/figcaption>
-&lt;/figure></code></pre>
-	</figure>
-	
 	<figure id="ex-05">
 		<figcaption>
 			<div class="label">Example &#8212; Image with label and caption on opposite sides</div>
@@ -305,14 +239,14 @@ layout: publishing/pages/topic
 	
 	<p>The following sections explain some of the better supported methods for adding extended descriptions
 		to images. Other methods are possible, but support in reading systems is often not as robust as in
-		browsers. For testing information, refer to the DIAGRAM Center's <a 
-			href="http://diagramcenter.org/best-practices-for-authoring-extended-descriptions.html">Best
-			Practices for Authoring Extended Descriptions in EPUB</a>.</p>
+		browsers. For testing information, refer to <a 
+			href="https://inclusivepublishing.org/ExtendedDescriptionsBestPractices">DAISY's Best Practices for
+			Implementing Extended Descriptions in EPUB</a>.</p>
 	
 	<section id="hyperlinks">
 		<h4>Hyperlinks</h4>
 		
-		<p>Plain old hyperlinks are one of the most widely accessible ways to direct users to a
+		<p>Plain old hyperlinks are the most widely accessible way to direct users to a
 			description. Adding an <code>aria-details</code> attribute to the image enables
 			assistive technologies to make the link available to the user when they encounter the
 			image instead of having to search for the link after.</p>
@@ -326,7 +260,7 @@ layout: publishing/pages/topic
 		<p>Note that a hyperlink does not always have to reference a description in another document;
 			descriptions might be included at the end of a section, like footnotes.</p>
 		
-		<p>In EPUB, when possible, the linked description should be in a file by itself to avoid issues
+		<p>When possible, the linked description should be in a file by itself to avoid issues
 			reaching the description (i.e., not all reading systems are able to locate the user properly 
 			when there are multiple descriptions in the same file). If there are many images, however,
 			adding each description to a separate file can bloat the spine (i.e., every description file
@@ -335,30 +269,112 @@ layout: publishing/pages/topic
 		<p>An image can be used to minimize the appearance of the link, but EPUB some reading systems
 			have issues with image links (they cannot be activated).</p>
 		
-		<p>Despite these shortcomings, however, hyperlinks are one of the more reliable techniques
-			currently supported in EPUB.</p>
+		<p>Despite these shortcomings, however, hyperlinks are the most reliable technique currently
+			supported in EPUB.</p>
 	</section>
 	
-	<section id="details">
-		<h4>The <code>details</code> element</h4>
+	<section id="poor-support">
+		<h4>Poorly supported techniques</h4>
 		
-		<p>The <code>details</code> element provides a collapsible means of including a description
-			for an image. The advantage of this element is that it allows both sighted and non-sighted
-			readers access to the description at their discretion (i.e., sighted readers can choose
-			whether to expand and read the description just as assistive technologies users can decide
-			whether to have the text read out).</p>
+		<p>The following techniques are often mentioned in guidelines for accessible HTML content, but
+			although they work well in browsers, their support in EPUB reading systems is currently limited.
+			Use of these techniques is only recommended if there is no better option available.</p>
 		
-		<p>Support for this element is not yet universal in EPUB, however. The element text may always
-			be open by default, and expanding the element when initially closed can cause problems with the
-			pagination produced by user agents (e.g., opening the element pushes content at the bottom of
-			the page out of view).</p>
+		<section id="hidden">
+			<h4>The <code>aria-describedBy</code> attribute</h4>
+			
+			<p>The <code>aria-describedBy</code> attribute allows a description to be linked directly
+				to an image. The description must be contained in an element in the same file as the image.
+				The ID of the element containing the description is the referenced from the 
+				<code>aria-describedBy</code> attribute.</p>
+			
+			<figure id="ex-04">
+				<figcaption>
+					<div class="label">Example &#8212; Hidden description</div>
+				</figcaption>
+				<pre id="ex-04-src" class="prettyprint linenums"><code>&lt;figure id="fig-01">
+   &lt;img
+      src="graphics/water-cycle.jpg"
+      alt="The hydrologic cycle, showing the 
+        circular nature of the process as water 
+        evaporates from a body of water and 
+        eventually returns to it"
+      aria-describedby="desc01"
+   &lt;figcaption>
+     The hydrologic cycle.
+     &lt;aside id="desc01">
+        &lt;h4>Description of hydrologic cycle&lt;/h4>
+        &lt;p>
+           The diagram shows the processes of 
+           evaporation, condensation,
+           evapotranspiration, water storage
+           in ice and snow, and precipitation.
+           A large body of water &#8230;
+        &lt;/p>
+     &lt;/aside>
+   &lt;/figcaption>
+&lt;/figure></code></pre>
+			</figure>
+			
+			<p>The element containing the description can be either visible or hidden content, although
+				it is generally not recommended to reference hidden content due to poor support in EPUB
+				reading systems. If the reading system does not support the <code>aria-describedby</code>
+				attribute, a visible description will still be accessible to all users.
+				
+			<p>Use of the <code>aria-describedby</code> attribute is not recommended when a description
+				contains structured markup like tables or lists, as all tagging is stripped and only the
+				text content is read to users.</p>
+		</section>
 		
-		<p>To use the element in EPUB publications, it is also recommended to put the element immediately
-			after a closing <code>figure</code> tag when the description is for a figure. The element often
-			does not work when included inside a <code>figure</code>.</p>
-		
-		<p>Despite these shortcomings, this element is still one of the more reliable techniques currently
-			supported in EPUB.</p>
+		<section id="details">
+			<h4>The <code>details</code> element</h4>
+			
+			<p>The <code>details</code> element provides a collapsible means of including a description
+				for an image. The advantage of this element is that it allows both sighted and non-sighted
+				readers access to the description at their discretion (i.e., sighted readers can choose
+				whether to expand and read the description just as assistive technologies users can decide
+				whether to have the text read out).</p>
+			
+			<p>Support for this element is not yet universal in EPUB, however. The element text may always
+				be open by default, and expanding the element when initially closed can cause problems with the
+				pagination produced by user agents (e.g., opening the element pushes content at the bottom of
+				the page out of view).</p>
+			
+			<p>If the <code>details</code> element must be used with a <code>figure</code> tag, put it immediately after 
+				the closing <code>&lt;/figure></code> tag. The <code>details</code> element often does not work when 
+				included inside a <code>figure</code>.</p>
+			
+			<figure id="ex-06">
+				<figcaption>
+					<div class="label">Example &#8212; Extended description in <code>details</code></div>
+					<p>The following example uses the HTML <code>details</code> element to create a description that is
+						collapsed from view by default. The <code>aria-details</code> attribute is used to associate
+						the image with the description.</p>
+				</figcaption>
+				<pre id="ex-02-src" class="prettyprint linenums"><code>&lt;figure id="fig-01">
+   &lt;figcaption>
+      The hydrologic cycle.
+   &lt;/figcaption>
+   &lt;img
+      src="graphics/water-cycle.jpg"
+      aria-details="fig-01-desc"
+      alt="The hydrologic cycle, showing the 
+        circular nature of the process as water 
+        evaporates from a body of water and 
+        eventually returns to it"/>
+&lt;/figure>
+&lt;details id="fig-01-desc">
+   &lt;summary>Description&lt;/summary>
+   &lt;p>
+      The diagram shows the processes of 
+      evaporation, condensation,
+      evapotranspiration, water storage
+      in ice and snow, and precipitation.
+      A large body of water &#8230;
+   &lt;/p>
+&lt;/details></code></pre>
+			</figure>
+		</section>
 	</section>
 </section>
 
@@ -367,9 +383,9 @@ layout: publishing/pages/topic
 <section id="refs">
 	<h3>Related Links</h3>
 	<ul>
-		<li>DIAGRAM &#8212; <a 
-			href="http://diagramcenter.org/best-practices-for-authoring-extended-descriptions.html">Best
-			Practices for Authoring Extended Descriptions in EPUB</a></li>
+		<li>DAISY &#8212; <a 
+				href="https://inclusivepublishing.org/ExtendedDescriptionsBestPractices">Best Practices for
+				Implementing Extended Descriptions in EPUB</a></li>
 		<li>DIAGRAM &#8212; <a href="https://poet.diagramcenter.org/">POET Image Description Training
 			Tool</a></li>
 		<li>MDN &#8212; <a

--- a/publishing/docs/new/2025.html
+++ b/publishing/docs/new/2025.html
@@ -1,0 +1,106 @@
+---
+title: 2024 Updates Archive
+language: en
+description: Archive of updates to the Accessible Publishing Knowledge Base from 2024
+canonical: https://kb.daisy.org/publishing/docs/new/2024.html
+layout: publishing/pages/blank
+---
+
+<section id="new" aria-label="2024 List of Updates">
+	<p>This page is an archive of changes to the knowledge base made in 2024. For the latest changes
+		to the site, refer to the site <a href="index.html">what's new</a> page.</p>
+	
+	<p>Changes are listed from most recent to oldest.</p>
+	
+	<dl class="value">
+		<dt>October 6, 2025 — <code>doc-pullquote</code> role tagging updated</dt>
+		<dd>
+			<p>The <code>doc-pullquote</code> role was corrected in DPUB-ARIA 1.1 to inherit its
+				semantics from the <code>section</code> role not <code>none</code>. This means
+				the guidance on adding a fallback <code>presentation</code> role no longer
+				applies. The <a href="../html/dpub-aria/doc-pullquote.html">page on <code>doc-pullquote</code></a>
+				in the knowledge base has been updated to reflect this revised usage.</p>
+		</dd>
+		
+		<dt>September 22, 2025 — Access mode and sufficient access mode updates</dt>
+		<dd>
+			<p>The <a href="../metadata/schema.org/accessMode.html">access mode</a>
+				and <a href="../metadata/schema.org/accessModeSufficient.html">sufficient access
+					mode</a> values are now covered in their own pages, providing updated information,
+				examples, and mappings to their ONIX equivalents.</p>
+			<p>The coverage of access modes has also been updated to the include visual content indicators -
+				<a href="../metadata/schema.org/accessMode/chartOnVisual.html"><code>chartOnVisual</code></a>,
+				<a href="../metadata/schema.org/accessMode/chemOnVisual.html"><code>chemOnVisual</code></a>,
+				<a href="../metadata/schema.org/accessMode/colorDependent.html"><code>colorDependent</code></a>,
+				<a href="../metadata/schema.org/accessMode/diagramOnVisual.html"><code>diagramOnVisual</code></a>,
+				<a href="../metadata/schema.org/accessMode/mathOnVisual.html"><code>mathOnVisual</code></a>,
+				<a href="../metadata/schema.org/accessMode/musicOnVisual.html"><code>musicOnVisual</code></a>, and
+				<a href="../metadata/schema.org/accessMode/textOnVisual.html"><code>textOnVisual</code></a>.</p>
+		</dd>
+		
+		<dt>August 28, 2025 — Accessibility hazards updates</dt>
+		<dd>
+			<p>The <a href="../metadata/schema.org/accessibilityHazard.html">accessibility hazard values</a>
+				are now covered in their own pages, providing updated information, examples of each value,
+				and mappings to their ONIX equivalents.</p>
+			<p>The coverage of values has also been updated to include the individual unknown
+				hazard properties -
+				<a href="../metadata/schema.org/accessibilityHazard/unknownFlashingHazard.html"><code>unknownFlashingHazard</code></a>,
+				<a href="../metadata/schema.org/accessibilityHazard/unknownMotionSimulationHazard.html"><code>unknownMotionSimulationHazard</code></a>, and
+				<a href="../metadata/schema.org/accessibilityHazard/unknownSoundHazard.html"><code>unknownSoundHazard</code></a>.
+			</p>
+		</dd>
+		
+		<dt>August 26, 2025 — Accessibility feature updates</dt>
+		<dd>
+			<p>New pages are now available describing how to use the recently added <code>latex-chemistry</code>
+				and <code>MathML-chemistry</code> pages.</p>
+			<p>The guidance on using the <code>annotations</code> value has been removed as the value
+				has been deprecated.</p>
+		</dd>
+		
+		<dt>August 26, 2025 — Added mappings from acceessibility features to ONIX</dt>
+		<dd>
+			<p>The <a href="../metadata/schema.org/accessibilityFeature.html">accessibilityFeature</a> 
+				value pages now include mappings to their ONIX counterparts.</p>
+		</dd>
+		
+		<dt>August 25, 2025 — Added coverage of ONIX codelist 81</dt>
+		<dd>
+			<p><a href="../metadata/onix/">Codelist 81</a> describes the type of content in a publication.
+				It is equivalent to the <a href="../metadata/schema.org/accessMode.html">schema.org access
+					modes</a>.</p>
+		</dd>
+		
+		<dt>August 12, 2025 — Added coverage of ONIX codelist 143</dt>
+		<dd>
+			<p>The section on ONIX metadata has been expanded to include coverage of <a 
+					href="../metadata/onix/codelist-143/">codelist 143</a>. This list defines codes
+				for expressing information about potential hazards.</p>
+		</dd>
+		
+		<dt>August 8, 2025 — ONIX metadata section expanded</dt>
+		<dd>
+			<p>The ONIX metadata page has been replaced by new pages that individually cover each of 
+				the <a href="../metadata/onix/codelist-196/">codes in list 196</a>. The update also adds
+				coverage of all the new codes added in recent ONIX updates. Future updates will add
+				coverage of codes outside of list 196 that are used to express accessibility information.</p>
+		</dd>
+		
+		<dt>July 8, 2025 — Prioritizing links to image descriptions</dt>
+		<dd>
+			<p>The page on <a href="https://kb.daisy.org/publishing/docs/html/images-desc.html">providing
+					image descriptions</a> has been updated to prioritize the current best practice of
+				using the <code>aria-details</code> attribute to reference a hyperlink to the
+				description.</p>
+		</dd>
+		
+		<dt>April 2, 2025 — Knowledge base now available in Japanese</dt>
+		<dd>
+			<p>The knowledge base has been <a href="https://kb.daisy.org/publishing/ja/">translated into
+					Japanese</a>. It is also available to Japanese users in the <a 
+						href="https://daisy.org/activities/software/ace/">Ace by DAISY</a> validation 
+				tool.</p>
+		</dd>
+	</dl>
+</section>

--- a/publishing/docs/new/feed.xml
+++ b/publishing/docs/new/feed.xml
@@ -5,9 +5,26 @@
 		<description>Recent updates to the DAISY Accessible Publishing KB</description>
 		<link>https://kb.daisy.org/publishing/docs</link>
 		<copyright>2025 DAISY. All rights reserved</copyright>
-		<lastBuildDate>Mon, 06 Oct 2025 00:01:00 +0500</lastBuildDate>
-		<pubDate>Mon, 06 OCt 2025 12:00:00 +0500</pubDate>
+		<lastBuildDate>Mon, 29 Jun 2026 00:01:00 +0500</lastBuildDate>
+		<pubDate>Mon, 29 Jun 2026 12:00:00 +0500</pubDate>
 		<ttl>1440</ttl>
+		
+		<item>
+			<title>Image description techniques updated</title>
+			<link>https://kb.daisy.org/publishing/docs/html/images-desc.html</link>
+			<description>
+				<![CDATA[
+				<p>The image description techniques have been updated to reflect recent changes to the 
+					recommendations in the <a 
+						href="https://inclusivepublishing.org/ExtendedDescriptionsBestPractices">DAISY Best Practices
+						for Implementing Extended Descriptions in EPUB</a>.</p>
+				<p>The use of hyperlinked descriptions remains the preferred technique, but the use of the
+					<code>details</code> element is no longer recommended at this time due to support issues
+					in reading systems.</p>
+				]]>	
+			</description>
+			<pubDate>Mon, 29 Jun 2026 12:00:00 +0500</pubDate>
+		</item>
 		
 		<item>
 			<title>doc-pullquote role tagging updated</title>

--- a/publishing/docs/new/index.html
+++ b/publishing/docs/new/index.html
@@ -50,94 +50,15 @@ layout: publishing/pages/blank
 	
 	<div id="update-list">
 		<dl class="value">
-			<dt>October 6, 2025 — <code>doc-pullquote</code> role tagging updated</dt>
+			<dt>June 29, 2026 — Image description techniques updated</dt>
 			<dd>
-				<p>The <code>doc-pullquote</code> role was corrected in DPUB-ARIA 1.1 to inherit its
-					semantics from the <code>section</code> role not <code>none</code>. This means
-					the guidance on adding a fallback <code>presentation</code> role no longer
-					applies. The <a href="../html/dpub-aria/doc-pullquote.html">page on <code>doc-pullquote</code></a>
-					in the knowledge base has been updated to reflect this revised usage.</p>
-			</dd>
-			
-			<dt>September 22, 2025 — Access mode and sufficient access mode updates</dt>
-			<dd>
-				<p>The <a href="../metadata/schema.org/accessMode.html">access mode</a>
-					and <a href="../metadata/schema.org/accessModeSufficient.html">sufficient access
-						mode</a> values are now covered in their own pages, providing updated information,
-					examples, and mappings to their ONIX equivalents.</p>
-				<p>The coverage of access modes has also been updated to the include visual content indicators -
-					<a href="../metadata/schema.org/accessMode/chartOnVisual.html"><code>chartOnVisual</code></a>,
-					<a href="../metadata/schema.org/accessMode/chemOnVisual.html"><code>chemOnVisual</code></a>,
-					<a href="../metadata/schema.org/accessMode/colorDependent.html"><code>colorDependent</code></a>,
-					<a href="../metadata/schema.org/accessMode/diagramOnVisual.html"><code>diagramOnVisual</code></a>,
-					<a href="../metadata/schema.org/accessMode/mathOnVisual.html"><code>mathOnVisual</code></a>,
-					<a href="../metadata/schema.org/accessMode/musicOnVisual.html"><code>musicOnVisual</code></a>, and
-					<a href="../metadata/schema.org/accessMode/textOnVisual.html"><code>textOnVisual</code></a>.</p>
-			</dd>
-			
-			<dt>August 28, 2025 — Accessibility hazards updates</dt>
-			<dd>
-				<p>The <a href="../metadata/schema.org/accessibilityHazard.html">accessibility hazard values</a>
-					are now covered in their own pages, providing updated information, examples of each value,
-					and mappings to their ONIX equivalents.</p>
-				<p>The coverage of values has also been updated to include the individual unknown
-					hazard properties -
-					<a href="../metadata/schema.org/accessibilityHazard/unknownFlashingHazard.html"><code>unknownFlashingHazard</code></a>,
-					<a href="../metadata/schema.org/accessibilityHazard/unknownMotionSimulationHazard.html"><code>unknownMotionSimulationHazard</code></a>, and
-					<a href="../metadata/schema.org/accessibilityHazard/unknownSoundHazard.html"><code>unknownSoundHazard</code></a>.
-				</p>
-			</dd>
-			
-			<dt>August 26, 2025 — Accessibility feature updates</dt>
-			<dd>
-				<p>New pages are now available describing how to use the recently added <code>latex-chemistry</code>
-					and <code>MathML-chemistry</code> pages.</p>
-				<p>The guidance on using the <code>annotations</code> value has been removed as the value
-					has been deprecated.</p>
-			</dd>
-			
-			<dt>August 26, 2025 — Added mappings from acceessibility features to ONIX</dt>
-			<dd>
-				<p>The <a href="../metadata/schema.org/accessibilityFeature.html">accessibilityFeature</a> 
-					value pages now include mappings to their ONIX counterparts.</p>
-			</dd>
-			
-			<dt>August 25, 2025 — Added coverage of ONIX codelist 81</dt>
-			<dd>
-				<p><a href="../metadata/onix/">Codelist 81</a> describes the type of content in a publication.
-					It is equivalent to the <a href="../metadata/schema.org/accessMode.html">schema.org access
-						modes</a>.</p>
-			</dd>
-			
-			<dt>August 12, 2025 — Added coverage of ONIX codelist 143</dt>
-			<dd>
-				<p>The section on ONIX metadata has been expanded to include coverage of <a 
-						href="../metadata/onix/codelist-143/">codelist 143</a>. This list defines codes
-					for expressing information about potential hazards.</p>
-			</dd>
-			
-			<dt>August 8, 2025 — ONIX metadata section expanded</dt>
-			<dd>
-				<p>The ONIX metadata page has been replaced by new pages that individually cover each of 
-					the <a href="../metadata/onix/codelist-196/">codes in list 196</a>. The update also adds
-					coverage of all the new codes added in recent ONIX updates. Future updates will add
-					coverage of codes outside of list 196 that are used to express accessibility information.</p>
-			</dd>
-			
-			<dt>July 8, 2025 — Prioritizing links to image descriptions</dt>
-			<dd>
-				<p>The page on <a href="https://kb.daisy.org/publishing/docs/html/images-desc.html">providing
-						image descriptions</a> has been updated to prioritize the current best practice of
-					using the <code>aria-details</code> attribute to reference a hyperlink to the
-					description.</p>
-			</dd>
-			
-			<dt>April 2, 2025 — Knowledge base now available in Japanese</dt>
-			<dd>
-				<p>The knowledge base has been <a href="https://kb.daisy.org/publishing/ja/">translated into
-						Japanese</a>. It is also available to Japanese users in the <a 
-							href="https://daisy.org/activities/software/ace/">Ace by DAISY</a> validation 
-					tool.</p>
+				<p>The <a href="../html/images-desc.html">image description techniques</a> have been updated to
+					reflect recent changes to the recommendations in the <a 
+						href="https://inclusivepublishing.org/ExtendedDescriptionsBestPractices">DAISY Best Practices
+						for Implementing Extended Descriptions in EPUB</a>.</p>
+				<p>The use of hyperlinked descriptions remains the preferred technique, but the use of the
+					<code>details</code> element is no longer recommended at this time due to support issues
+					in reading systems.</p>
 			</dd>
 		</dl>
 	</div>


### PR DESCRIPTION
I've de-emphasized details and aria-describedby by moving them to a new "poorly supported techniques" subsection. I also updated the link to the best practices guide.

You can sort of preview the changes at the following link, but as it's a jekyll template file it's pretty basic html with metadata visible at the top:
https://raw.githack.com/daisy/kb/update/extended-desc/publishing/docs/html/images-desc.html

/cc @clapierre @gregoriopellegrino @avneeshsingh @GeorgeKerscher 